### PR TITLE
feat: implement user active status check in JWT validation

### DIFF
--- a/apps/backend/src/auth/jwt.strategy.ts
+++ b/apps/backend/src/auth/jwt.strategy.ts
@@ -1,14 +1,13 @@
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
-import { Inject, Injectable } from '@nestjs/common';
-import { UsersService } from 'src/users/users.service';
-import { UUID } from 'node:crypto';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { jwtConstants } from './constants';
-import { AuthService } from './auth.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { TokenDto } from 'src/common/dto/token.dto';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor() {
+  constructor(private readonly prisma: PrismaService) {
     if (!jwtConstants.secret) {
       throw new Error('JWT secret is not defined');
     }
@@ -19,7 +18,15 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  validate(payload) {
-    return payload;
+  async validate(payload: TokenDto) {
+    const user = await this.prisma.usuario.findUnique({
+      where: { id_User: payload.sub },
+    });
+
+    if (!user || !user.isActive) {
+      throw new UnauthorizedException();
+    }
+
+    return user;
   }
 }


### PR DESCRIPTION
This pull request updates the JWT authentication strategy to improve user validation and security. The main changes involve switching from returning the raw JWT payload to fetching the user from the database and verifying their active status.

**Authentication and validation improvements:**

* The `JwtStrategy` now injects `PrismaService` to query the database for the user associated with the JWT, instead of simply returning the payload.
* The `validate` method now checks if the user exists and is active (`isActive` flag); if not, it throws an `UnauthorizedException`, preventing inactive or non-existent users from authenticating.