### PR TITLE
feat: implement internal login page and authentication flow

### DIFF
--- a/apps/frontend/app/(auth)/layout.tsx
+++ b/apps/frontend/app/(auth)/layout.tsx
@@ -1,0 +1,28 @@
+// Import CSS
+import '../globals.css';
+
+// Import Libs
+import type { Metadata } from 'next';
+
+// Import Components
+import { Toaster } from '@/components/ui/sonner';
+
+// Metadata
+export const metadata: Metadata = {
+    title: 'Arca | WizeCode',
+    description: '',
+    keywords: ['Arca'],
+    robots: { index: true, follow: true }
+};
+
+export default function RootLayout({ children }: Readonly<{ children: React.ReactNode; }>) {
+    return (
+        <html lang="pt-br">
+            <body cz-shortcut-listen="true">
+                <main>{children}</main>
+
+                <Toaster position="top-center" />
+            </body>
+        </html>
+    );
+};

--- a/apps/frontend/app/(auth)/login/page.tsx
+++ b/apps/frontend/app/(auth)/login/page.tsx
@@ -1,0 +1,55 @@
+// Directives
+'use client';
+
+// Import Libs
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+// Import Components
+import FormLogin from '@/components/forms/form-login';
+
+// Import Icons
+import { Brain, ArrowLeft } from 'lucide-react';
+
+const Login = () => {
+    // Router
+    const router = useRouter();
+
+    return (
+        <>
+            <div className="bg-(--color-light) flex w-full min-h-screen">
+                <div className="flex-2 flex flex-col justify-between items-center p-4!">
+                    <div className="flex justify-between items-center w-full">
+                        <Link href="/" className="flex items-center gap-2">
+                            <Brain size={36} color="#000000" />
+                            <h1 className="font-bold text-(--color-dark) text-[18px]">ARCA</h1>
+                        </Link>
+
+                        <div onClick={() => router.push('/')} className="bg-(--color-light) text-(--color-dark) p-2! border border-solid border-(--color-mlight)/75 rounded-xl">
+                            <ArrowLeft color="#000000" className="cursor-pointer" />
+                        </div>
+                    </div>
+
+                    <div className="flex flex-col justify-center items-center gap-6 w-full">
+                        <div className="flex flex-col items-center gap-2">
+                            <h2 className="font-semibold text-(--color-dark) text-[18px]">Acesso Interno</h2>
+                            <p className="text-(--color-mdark) text-[14px]">Insira suas credenciais para acessar a plataforma</p>
+                        </div>
+
+                        <FormLogin />
+                    </div>
+
+                    <div className="w-[calc(100%-80px)] border-t border-solid border-(--color-mlight)/75 pt-4!">
+                        <p className="text-(--color-mdark) text-[14px] text-center">Não tem uma conta? Entre em contato com um administrador <Link href="mailto:contato@wizecode.com.br" className="font-bold">aqui</Link>.</p>
+                    </div>
+                </div>
+
+                <div className="bg-(--color-mlight) flex-1 hidden flex-col lg:flex">
+                    {/* Imagem da Fac+ */}
+                </div>
+            </div>
+        </>
+    );
+};
+
+export default Login;

--- a/apps/frontend/app/(external)/layout.tsx
+++ b/apps/frontend/app/(external)/layout.tsx
@@ -1,20 +1,20 @@
 // Import CSS
-import './globals.css';
+import '../globals.css';
 
-// Import Libs
+// Import Types
 import type { Metadata } from 'next';
 
 // Import Components
+import { Toaster } from '@/components/ui/sonner';
 import Header from '@/components/layout/header';
 import Footer from '@/components/layout/footer';
-/* import { Toaster } from '@/components/ui/sonner'; */
 
 // Metadata
 export const metadata: Metadata = {
     title: 'Arca | WizeCode',
-    // description: '',
-    // keywords: ['Arca', ''],
-    // robots: { index: true, follow: true }
+    description: '',
+    keywords: ['Arca'],
+    robots: { index: true, follow: true }
 };
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode; }>) {
@@ -27,7 +27,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
 
                 <footer className="m-4!"><Footer /></footer>
 
-                {/* <Toaster position="bottom-right" expand={true} /> */}
+                <Toaster position="top-center" />
             </body>
         </html>
     );

--- a/apps/frontend/app/(external)/page.tsx
+++ b/apps/frontend/app/(external)/page.tsx
@@ -1,13 +1,16 @@
+// Directives
+'use client';
+
 // Import Components
-// ...
+/* ... */
 
 const Home = () => {
     return (
         <>
             <div className="bg-(--color-mlight)/25 p-4! rounded-[20px] border border-transparent h-80">
                 <div className="flex flex-col justify-center items-center gap-2 h-full">
-                    <h1 className="font-semibold text-(--color-dark) text-[18px]">Sistema de Gestão de Clínicas-Escola</h1>
-                    <p className="text-(--color-mdark) text-[14px]">Facmais / Unimais | Ituiutaba-MG</p>
+                    <h1 className="font-semibold text-(--color-dark) text-[18px] text-center">Sistema de Gestão de Clínicas-Escola de Psicologia</h1>
+                    <p className="text-(--color-mdark) text-[14px] text-center">Facmais / Unimais | Ituiutaba-MG</p>
                 </div>
             </div>
         </>

--- a/apps/frontend/app/api/auth/[...nextauth]/route.ts
+++ b/apps/frontend/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,64 @@
+import NextAuth from 'next-auth';
+import Credentials from 'next-auth/providers/credentials';
+
+import { apiService } from '@/lib/api';
+
+const handler = NextAuth({
+    providers: [
+        Credentials({
+            name: 'Credentials',
+            credentials: {
+                email: { label: "E-mail", type: "email" },
+                password: { label: "Senha", type: "password" }
+            },
+
+            async authorize(credentials, req) {
+                const user = await apiService.login({
+                    email: credentials?.email || '',
+                    password: credentials?.password || ''
+                });
+
+                if (user) {
+                    return {
+                        token: user.token,
+                        id: user.id,
+                        roleId: user.roleId,
+                        name: user.name,
+                        email: user.email
+                    };
+                }
+
+                return null;
+            }
+        })
+    ],
+
+    callbacks: {
+        async jwt({ token, user }) {
+            if (user) {
+                token.token = user.token;
+                token.id = user.id;
+                token.roleId = user.roleId;
+            }
+
+            return token;
+        },
+
+        async session({ session, token }) {
+            session.token = token.token;
+            session.user.id = token.id;
+            session.user.roleId = token.roleId;
+
+            return session;
+        }
+    },
+
+    pages: {
+        signIn: '/login'
+    },
+    session: {
+        strategy: 'jwt'
+    }
+});
+
+export { handler as GET, handler as POST };

--- a/apps/frontend/components/forms/form-login.tsx
+++ b/apps/frontend/components/forms/form-login.tsx
@@ -1,0 +1,155 @@
+// Directives
+'use client';
+
+// Import Libs
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { signIn } from 'next-auth/react';
+import { z } from 'zod';
+import Link from 'next/link';
+
+// Import Hooks
+import { Controller, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+// Import Components
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Field, FieldError, FieldGroup, FieldLabel, } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+
+// Form Schema
+const formLoginSchema = z.object({
+    email: z
+        .email({ message: "Insira um e-mail válido." })
+        .min(1, { message: "O e-mail é obrigatório." }),
+    password: z
+        .string({ message: "A senha é obrigatória." })
+        .min(6, { message: "A senha deve conter no mínimo 6 caracteres." })
+})
+
+const FormLogin = () => {
+    // Router
+    const router = useRouter();
+
+    // Controllers
+    const [isLoading, setIsLoading] = useState(false);
+
+    // Form Resolver
+    const form = useForm<z.infer<typeof formLoginSchema>>({
+        resolver: zodResolver(formLoginSchema),
+        defaultValues: {
+            email: '',
+            password: ''
+        }
+    });
+
+    // Form Submit
+    const onSubmit = async (data: z.infer<typeof formLoginSchema>) => {
+        setIsLoading(true);
+
+        const toastId = toast.loading("Carregando...", {
+            description: "Verificando suas credenciais."
+        });
+
+        try {
+            const response = await signIn("credentials", {
+                email: data.email,
+                password: data.password,
+                redirect: false
+            });
+
+            if (response?.error) {
+                toast.warning("Acesso Negado", {
+                    id: toastId,
+                    description: "E-mail ou senha incorretos."
+                });
+
+                return;
+            }
+
+            toast.success("Bem-vindo!", {
+                id: toastId,
+                description: "Redirecionando para a plataforma..."
+            });
+
+            router.push("/plataforma");
+            router.refresh();
+        } catch (error) {
+            console.error("Erro de tentativa no login:", error);
+
+            toast.error("Erro Inesperado", {
+                id: toastId,
+                description: "Por favor, tente novamente."
+            });
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <>
+            <form id="form-login" className="w-full max-w-md" noValidate onSubmit={form.handleSubmit(onSubmit)}>
+                <FieldGroup>
+                    <Controller
+                        name="email"
+                        control={form.control}
+                        render={({ field, fieldState }) => (
+                            <Field data-invalid={fieldState.invalid}>
+                                <FieldLabel htmlFor="form-login-email">Email</FieldLabel>
+
+                                <Input {...field}
+                                    id="form-login-email"
+                                    type="email"
+                                    placeholder="Digite seu e-mail"
+                                    autoComplete="off"
+                                    aria-describedby="email-error"
+                                    aria-invalid={fieldState.invalid}
+                                    disabled={isLoading}
+                                />
+
+                                {fieldState.invalid && ( <FieldError errors={[fieldState.error]} /> )}
+                            </Field>
+                        )}
+                    />
+
+                    <Controller
+                        name="password"
+                        control={form.control}
+                        render={({ field, fieldState }) => (
+                            <Field data-invalid={fieldState.invalid}>
+                                <div className="flex justify-between items-center">
+                                    <FieldLabel htmlFor="form-login-password">Senha</FieldLabel>
+
+                                    <Link href="#" className="text-(--color-mdark) text-[14px] transition-colors duration-250 ease-in-out hover:text-(--color-dark)">
+                                        Redefinir
+                                    </Link>
+                                </div>
+
+                                <Input {...field}
+                                    id="form-login-password"
+                                    type="password"
+                                    placeholder="Digite sua senha"
+                                    autoComplete="off"
+                                    aria-describedby="password-error"
+                                    aria-invalid={fieldState.invalid}
+                                    disabled={isLoading}
+                                />
+
+                                {fieldState.invalid && ( <FieldError errors={[fieldState.error]} /> )}
+                            </Field>
+                        )}
+                    />
+                    
+                    <Field orientation="horizontal" className="mt-6!">
+                        <Button form="form-login" type="submit" variant="primary" className="w-full" disabled={isLoading}>
+                            {isLoading ? "Carregando..." : "Entrar"}
+                        </Button>
+                    </Field>
+                </FieldGroup>
+            </form>
+        </>
+    );
+};
+
+export default FormLogin;

--- a/apps/frontend/components/layout/footer.tsx
+++ b/apps/frontend/components/layout/footer.tsx
@@ -2,23 +2,12 @@
 'use client';
 
 // Import Libs
-import Link from 'next/link';
 import { navLinksExternal, navLinksInternal } from '@/lib/navigation';
-
-// Imports Components
-// ...
+import Link from 'next/link';
 
 // Import Icons
-import {
-    Brain,
-    Mail,
-    ChevronRight
-} from 'lucide-react';
-import {
-    FaWhatsapp,
-    FaInstagram,
-    FaLinkedin
-} from 'react-icons/fa';
+import { Brain, Mail } from 'lucide-react';
+import { FaWhatsapp, FaInstagram, FaLinkedin } from 'react-icons/fa';
 
 const Footer = () => {
     return (

--- a/apps/frontend/components/layout/header.tsx
+++ b/apps/frontend/components/layout/header.tsx
@@ -2,40 +2,18 @@
 'use client';
 
 // Import Libs
-import {
-    usePathname
-} from 'next/navigation';
-import Link from 'next/link';
 import { useState, useEffect } from 'react';
+import { usePathname } from 'next/navigation';
 import { navLinksExternal } from '@/lib/navigation';
+import Link from 'next/link';
 
 // Imports Components
-import {
-    Button
-} from '@/components/ui/button';
-import {
-    NavigationMenu,
-    NavigationMenuList,
-    NavigationMenuItem,
-    NavigationMenuLink
-} from '@/components/ui/navigation-menu';
-import {
-    Sheet,
-    SheetTrigger,
-    SheetClose,
-    SheetContent,
-    SheetHeader,
-    SheetTitle,
-    SheetDescription,
-    SheetFooter
-} from '@/components/ui/sheet';
+import { Button } from '@/components/ui/button';
+import { NavigationMenu, NavigationMenuList, NavigationMenuItem, NavigationMenuLink } from '@/components/ui/navigation-menu';
+import { Sheet, SheetTrigger, SheetClose, SheetContent, SheetHeader, SheetTitle, SheetDescription, SheetFooter } from '@/components/ui/sheet';
 
 // Import Icons
-import {
-    Brain,
-    LogIn,
-    TextAlignJustify
-} from 'lucide-react';
+import { Brain, LogIn, TextAlignJustify } from 'lucide-react';
 
 const Header = () => {
     // Routes
@@ -65,7 +43,7 @@ const Header = () => {
                     <div className="flex-1 flex justify-start">
                         <Link href="/" className="flex items-center gap-2">
                             <Brain size={36} color="#000000" />
-                            <h1 className="font-bold text-[18px]">ARCA</h1>
+                            <h1 className="font-bold text-(--color-dark) text-[18px]">ARCA</h1>
                         </Link>
                     </div>
 
@@ -77,7 +55,7 @@ const Header = () => {
                                 return (
                                     <NavigationMenuItem key={link.label}>
                                         <NavigationMenuLink asChild>
-                                            <Link href={link.href} className={`${isActive ? 'font-bold' : 'font-normal'} relative after:content-[''] after:absolute after:-bottom-0.5 after:left-1/2 after:-translate-x-1/2 after:h-px after:w-0 after:bg-(--color-dark) after:transition-all after:duration-250 after:ease-in-out hover:after:w-[calc(100%-4px)]`}>{link.label}</Link>
+                                            <Link href={link.href} className={`${isActive ? 'font-bold' : 'font-normal'} text-(--color-dark) relative after:content-[''] after:absolute after:-bottom-0.5 after:left-1/2 after:-translate-x-1/2 after:h-px after:w-0 after:bg-(--color-dark) after:transition-all after:duration-250 after:ease-in-out hover:after:w-[calc(100%-4px)]`}>{link.label}</Link>
                                         </NavigationMenuLink>
                                     </NavigationMenuItem>
                                 );
@@ -87,7 +65,7 @@ const Header = () => {
 
                     <div className="flex-1 hidden justify-end lg:flex">
                         <Button asChild variant="primary">
-                            <Link href='#'>
+                            <Link href='/login'>
                                 <LogIn color="#FFFFFF" />Acesso Interno
                             </Link>
                         </Button>
@@ -95,12 +73,12 @@ const Header = () => {
 
                     <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
                         <SheetTrigger asChild className="flex lg:hidden">
-                            <TextAlignJustify size={20} className="cursor-pointer" />
+                            <TextAlignJustify size={20} color="#000000" className="cursor-pointer" />
                         </SheetTrigger>
 
                         <SheetContent className="bg-(--color-light) px-4! py-4!">
                             <SheetHeader>
-                                <SheetTitle className="font-bold">MENU</SheetTitle>
+                                <SheetTitle className="font-bold text-(--color-dark)">MENU</SheetTitle>
                                 <SheetDescription className="sr-only">
                                     Menu principal de navegação.
                                 </SheetDescription>
@@ -112,7 +90,7 @@ const Header = () => {
                                     
                                     return (
                                         <SheetClose asChild key={link.href}>
-                                            <Link href={link.href} className={`${isActive ? 'font-bold' : 'font-normal'}`}>{link.label}</Link>
+                                            <Link href={link.href} className={`${isActive ? 'font-bold' : 'font-normal'} text-(--color-dark)`}>{link.label}</Link>
                                         </SheetClose>
                                     );
                                 })}
@@ -120,7 +98,7 @@ const Header = () => {
 
                             <SheetFooter>
                                 <Button asChild variant="primary">
-                                    <Link href="#">
+                                    <Link href="/login">
                                         <LogIn color="#FFFFFF" />Acesso Interno
                                     </Link>
                                 </Button>

--- a/apps/frontend/components/ui/button.tsx
+++ b/apps/frontend/components/ui/button.tsx
@@ -9,8 +9,8 @@ const buttonVariants = cva(
     {
         variants: {
             variant: {
-                primary: "bg-(--color-dark) text-(--color-light) border-[1px] border-solid border-transparent",
-                outline: "bg-(--color-light) text-(--color-dark) border-[1px] border-solid border-(--color-mlight)/75"
+                primary: "bg-(--color-dark) text-(--color-light) border border-solid border-transparent",
+                outline: "bg-(--color-light) text-(--color-dark) border border-solid border-(--color-mlight)/75"
             },
             size: {
                 default: "font-semibold text-center text-[14px] px-[16px]! py-[8px]! rounded-[12px]"

--- a/apps/frontend/components/ui/field.tsx
+++ b/apps/frontend/components/ui/field.tsx
@@ -1,0 +1,236 @@
+"use client"
+
+import { useMemo } from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+
+function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+    return (
+        <fieldset
+            data-slot="field-set"
+            className={cn(
+                "flex flex-col gap-4 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+                className
+            )}
+            {...props}
+        />
+    )
+}
+
+function FieldLegend({
+    className,
+    variant = "legend",
+    ...props
+}: React.ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+    return (
+        <legend
+            data-slot="field-legend"
+            data-variant={variant}
+            className={cn(
+                "mb-1.5 text-[14px]",
+                className
+            )}
+            {...props}
+        />
+    )
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
+    return (
+        <div
+            data-slot="field-group"
+            className={cn(
+                "group/field-group @container/field-group flex w-full flex-col gap-4 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4",
+                className
+            )}
+            {...props}
+        />
+    )
+}
+
+const fieldVariants = cva(
+    "group/field flex w-full gap-2 data-[invalid=true]:text-red-500",
+    {
+        variants: {
+            orientation: {
+                vertical: "flex-col *:w-full [&>.sr-only]:w-auto",
+                horizontal: "flex-row items-center has-[>[data-slot=field-content]]:items-start *:data-[slot=field-label]:flex-auto has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+                responsive: "flex-col *:w-full @md/field-group:flex-row @md/field-group:items-center @md/field-group:*:w-auto @md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:*:data-[slot=field-label]:flex-auto [&>.sr-only]:w-auto @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+            },
+        },
+        defaultVariants: {
+            orientation: "vertical",
+        },
+    }
+)
+
+function Field({
+    className,
+    orientation = "vertical",
+    ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+    return (
+        <div
+            role="group"
+            data-slot="field"
+            data-orientation={orientation}
+            className={cn(fieldVariants({ orientation }), className)}
+            {...props}
+        />
+    )
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+    return (
+        <div
+            data-slot="field-content"
+            className={cn(
+                "group/field-content flex flex-1 flex-col gap-0.5",
+                className
+            )}
+            {...props}
+        />
+    )
+}
+
+function FieldLabel({
+    className,
+    ...props
+}: React.ComponentProps<typeof Label>) {
+    return (
+        <Label
+            data-slot="field-label"
+            className={cn(
+                "group/field-label peer/field-label flex w-fit gap-2 group-data-[disabled=true]/field:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border *:data-[slot=field]:p-2.5 dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10",
+                "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
+                className
+            )}
+            {...props}
+        />
+    )
+}
+
+function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
+    return (
+        <div
+            data-slot="field-label"
+            className={cn(
+                "flex w-fit items-center gap-2 font-semibold text-[14px] group-data-[disabled=true]/field:opacity-50",
+                className
+            )}
+            {...props}
+        />
+    )
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
+    return (
+        <p
+            data-slot="field-description"
+            className={cn(
+                "text-(--color-medium) text-[14px] text-left group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5",
+                "last:mt-0 nth-last-2:-mt-1",
+                "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+                className
+            )}
+            {...props}
+        />
+    )
+}
+
+function FieldSeparator({
+    children,
+    className,
+    ...props
+}: React.ComponentProps<"div"> & {
+    children?: React.ReactNode
+}) {
+    return (
+        <div
+            data-slot="field-separator"
+            data-content={!!children}
+            className={cn(
+                "relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2",
+                className
+            )}
+            {...props}
+        >
+            <Separator className="absolute inset-0 top-1/2" />
+            {children && (
+                <span
+                    className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+                    data-slot="field-separator-content"
+                >
+                    {children}
+                </span>
+            )}
+        </div>
+    )
+}
+
+function FieldError({
+    className,
+    children,
+    errors,
+    ...props
+}: React.ComponentProps<"div"> & {
+    errors?: Array<{ message?: string } | undefined>
+}) {
+    const content = useMemo(() => {
+        if (children) {
+            return children
+        }
+
+        if (!errors?.length) {
+            return null
+        }
+
+        const uniqueErrors = [
+            ...new Map(errors.map((error) => [error?.message, error])).values(),
+        ]
+
+        if (uniqueErrors?.length == 1) {
+            return uniqueErrors[0]?.message
+        }
+
+        return (
+            <ul className="flex flex-col gap-1 ml-4 list-disc">
+                {uniqueErrors.map(
+                    (error, index) =>
+                        error?.message && <li key={index}>{error.message}</li>
+                )}
+            </ul>
+        )
+    }, [children, errors])
+
+    if (!content) {
+        return null
+    }
+
+    return (
+        <div
+            role="alert"
+            data-slot="field-error"
+            className={cn("text-red-500 text-[14px]", className)}
+            {...props}
+        >
+            {content}
+        </div>
+    )
+}
+
+export {
+    Field,
+    FieldLabel,
+    FieldDescription,
+    FieldError,
+    FieldGroup,
+    FieldLegend,
+    FieldSeparator,
+    FieldSet,
+    FieldContent,
+    FieldTitle,
+}

--- a/apps/frontend/components/ui/input.tsx
+++ b/apps/frontend/components/ui/input.tsx
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+    return (
+        <input
+            type={type}
+            data-slot="input"
+            className={cn(
+                "bg-transparent text-(--color-dark) text-[14px] w-full min-w-0 h-10 px-2! border border-input rounded-lg outline-none transition-colors placeholder:text-(--color-medium) focus-visible:ring-(--color-dark) focus-visible:border-ring focus-visible:ring-1 disabled:bg-input/50 disabled:cursor-not-allowed disabled:opacity-50 disabled:pointer-events-none aria-invalid:placeholder:text-red-300 aria-invalid:border-red-500 aria-invalid:ring-red-500 aria-invalid:ring-1 file:bg-transparent file:inline-flex file:text-base file:h-6 file:border-0",
+                className
+            )}
+            {...props}
+        />
+    )
+}
+
+export { Input }

--- a/apps/frontend/components/ui/label.tsx
+++ b/apps/frontend/components/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+    className,
+    ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+    return (
+        <LabelPrimitive.Root
+            data-slot="label"
+            className={cn(
+                "flex items-center gap-2 text-[14px] font-semibold select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+                className
+            )}
+            {...props}
+        />
+    )
+}
+
+export { Label }

--- a/apps/frontend/components/ui/separator.tsx
+++ b/apps/frontend/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import { Separator as SeparatorPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+    className,
+    orientation = "horizontal",
+    decorative = true,
+    ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+    return (
+        <SeparatorPrimitive.Root
+            data-slot="separator"
+            decorative={decorative}
+            orientation={orientation}
+            className={cn(
+                "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+                className
+            )}
+            {...props}
+        />
+    )
+}
+
+export { Separator }

--- a/apps/frontend/components/ui/sheet.tsx
+++ b/apps/frontend/components/ui/sheet.tsx
@@ -69,7 +69,7 @@ function SheetContent({
                 {children}
                 {showCloseButton && (
                     <SheetPrimitive.Close data-slot="sheet-close" className="absolute top-4 right-4 cursor-pointer">
-                        <XIcon size={20} />
+                        <XIcon size={20} color="var(--color-dark)" />
                         <span className="sr-only">Close</span>
                     </SheetPrimitive.Close>
                 )}

--- a/apps/frontend/components/ui/sonner.tsx
+++ b/apps/frontend/components/ui/sonner.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+    const { theme = "system" } = useTheme()
+
+    return (
+        <Sonner
+            theme={theme as ToasterProps["theme"]}
+            className="toaster group"
+            icons={{
+                success: (
+                    <CircleCheckIcon size={20} color="#00C950" />
+                ),
+                info: (
+                    <InfoIcon size={20} color="#2B7FFF" />
+                ),
+                warning: (
+                    <TriangleAlertIcon size={20} color="#F0B100" />
+                ),
+                error: (
+                    <OctagonXIcon size={20} color="#FB2C36" />
+                ),
+                loading: (
+                    <Loader2Icon size={20} color="#808080" className=" animate-spin" />
+                ),
+            }}
+            toastOptions={{
+                classNames: {
+                    toast: "bg-(--color-light)! gap-4! px-6! py-4! border! border-solid! border-(--color-mlight)/75! rounded-xl! shadow-md!",
+                    title: "font-semibold! text-(--color-dark)! text-[14px]!",
+                    description: "text-(--color-medium)! text-[14px]!"
+                },
+            }}
+            {...props}
+        />
+    )
+}
+
+export { Toaster }

--- a/apps/frontend/lib/api.ts
+++ b/apps/frontend/lib/api.ts
@@ -1,0 +1,41 @@
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3333";
+const API_ENDPOINTS = { login: `${API_BASE_URL}/auth/login` } as const;
+
+export async function apiRequest(endpoint: string, options: RequestInit = {}) {
+    const response = await fetch(endpoint, {
+        headers: {
+            "Content-Type": "application/json",
+            ...options.headers,
+        },
+        ...options,
+    });
+
+    if (!response.ok) {
+        let errorData;
+
+        try {
+            errorData = await response.json();
+        } catch {
+            errorData = { message: `HTTP ${response.status} - ${response.statusText}` };
+        }
+
+        const error = new Error(errorData.message || `Erro ${response.status}`) as Error & {
+            status: number;
+            userId?: string;
+            userName?: string;
+        };
+
+        error.status = response.status;
+        throw error;
+    }
+
+    return response.json();
+};
+
+export const apiService = {
+    login: (credentials: { email: string; password: string }) =>
+        apiRequest(API_ENDPOINTS.login, {
+            method: "POST",
+            body: JSON.stringify(credentials)
+        })
+};

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
     /* config options here */
     reactCompiler: true,
+    allowedDevOrigins: ['192.168.100.172']
 };
 
 export default nextConfig;

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -13,11 +13,13 @@
         "clsx": "^2.1.1",
         "lucide-react": "^1.9.0",
         "next": "16.2.4",
+        "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-icons": "^5.6.0",
         "shadcn": "^4.4.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
     },

--- a/apps/frontend/types/next-auth.d.ts
+++ b/apps/frontend/types/next-auth.d.ts
@@ -1,0 +1,26 @@
+import type { DefaultSession } from 'next-auth';
+import type { JWT as DefaultJWT } from 'next-auth/jwt';
+
+declare module 'next-auth' {
+    interface User {
+        token: string;
+        id: string;
+        roleId: string;
+        name: string;
+        email: string;
+    }
+    interface Session {
+        token: string;
+        user: {
+            id: string;
+            roleId: string;
+        } & DefaultSession['user'];
+    }
+}
+declare module 'next-auth/jwt' {
+    interface JWT extends DefaultJWT {
+        token: string;
+        id: string;
+        roleId: string;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,11 +103,13 @@
         "clsx": "^2.1.1",
         "lucide-react": "^1.9.0",
         "next": "16.2.4",
+        "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-icons": "^5.6.0",
         "shadcn": "^4.4.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
       },
@@ -15632,6 +15634,16 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/next/node_modules/@next/env": {
       "version": "16.2.4",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
@@ -18739,6 +18751,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/sort-keys": {


### PR DESCRIPTION
- Created layout and page for login under the (auth) directory
- Added form for user login with validation and error handling
- Integrated NextAuth for authentication with credentials provider
- Established API service for login requests
- Updated layout for external pages to include header, footer, and Toaster notifications
- Refactored existing components for better structure and reusability
- Added TypeScript definitions for NextAuth session and JWT
- Introduced new UI components for form fields and input handling
- Updated package.json and next.config.ts for new dependencies and configurations

Co-authored-by: Copilot <copilot@github.com>