### PR TITLE
docs: aplica documentação de arquitetura e convenções gerada em sessão de planejamento

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,79 @@
+# AGENTS.md
+
+Regras de trabalho neste repositório. Valem para qualquer agente de IA.
+Este é o resumo imperativo. Para o **porquê** de cada regra, com exemplos:
+
+- `CLAUDE.md` — referência técnica: comandos, módulos, estrutura, env vars
+- `docs/CONVENTIONS.md` — padrões de componente e fluxo de versionamento
+- `docs/adr/` — decisões de arquitetura já tomadas, uma por arquivo
+- `docs/ARQUITETURA.md` — visão geral do sistema, status por módulo
+
+## Stack
+
+Backend: NestJS · Prisma · PostgreSQL.
+Frontend: Next.js (App Router) · TypeScript · TailwindCSS · shadcn/ui.
+Sem testes automatizados no frontend ainda: valide com `npm run typecheck`,
+`npm run lint`, `npm run build` e o navegador. Backend tem testes — rode
+`npm run -w backend test` antes de propor qualquer PR que toque nele.
+
+## Componentes (frontend)
+
+- Copy estático de UI (título, empty state, texto de botão) nunca vive dentro
+  do componente — vai em `app/**/<rota>.data.ts`. Sem exceção de tamanho.
+- Dado dinâmico de aplicação (paciente, atendimento, prontuário) vem por
+  Server Action, nunca por `.data.ts`.
+- Props de conteúdo são obrigatórias, sem default. Só prop de layout
+  (`variant`) pode ter default.
+- Se a variação cabe num `cva()`, é variante. Se muda a árvore HTML, é
+  componente novo.
+- Componente nasce colocado dentro do módulo que o usa
+  (`app/(auth)/plataforma/<modulo>/`). Só sobe pra `components/shared/` quando
+  um **segundo** módulo precisa dele de verdade.
+- Página de listagem usa `components/templates/list-page.tsx`. Página de
+  registro usa `components/templates/detail-page.tsx`.
+- Toda leitura/escrita de dado no frontend passa por Server Action. Route
+  Handlers existem só para o NextAuth. Nenhuma env var `NEXT_PUBLIC_` além do
+  que o NextAuth exige.
+
+## Onde cada componente mora
+
+| Pasta | O que entra |
+| --- | --- |
+| `components/ui/` | primitivos shadcn/ui |
+| `components/layout/` | só chrome global (sidebar, header) |
+| `components/forms/` | `fields/` + `form-layout` + formulários concretos |
+| `components/sheets/` | modais de ação (`sheet-[nome].tsx`) |
+| `components/templates/` | `list-page.tsx`, `detail-page.tsx` |
+| `components/shared/` | promovido só após uso em 2+ módulos |
+| `app/**/<modulo>/*.tsx` (fora `page.tsx`) | componente específico daquele módulo |
+
+## Fornecedores (analytics, flags)
+
+Nunca importar SDK de fornecedor direto em página ou componente — sempre atrás
+de uma interface própria em `lib/`. Relevante em especial pra qualquer dado
+tocando prontuário/paciente (LGPD).
+
+## Idioma
+
+Inglês: código, nomes de arquivo, componentes, comentários.
+Português: rotas e todo copy/conteúdo voltado ao usuário.
+
+## Backend (NestJS)
+
+Lógica de negócio migra para classes de domínio (`Atendimento`, `Prontuario`
+com `fromPrisma()`/`fromJSON()`) — ver `docs/adr/` e `CLAUDE.md` para o estado
+atual disso. Todo endpoint novo em modelo com `id_Clinica` deve respeitar o
+escopo de tenant — não confiar em lembrar disso, usar o mecanismo de
+enforcement quando existir.
+
+## Git e versionamento
+
+- `feature/*` / `fix/*` nascem de `development` → PR com **squash**.
+- `development` → `release/x.y.z` quando pronto pra congelar uma versão.
+- `release/*` → `main` **e** → `development`: merge normal, **nunca** squash.
+- `hotfix/*` nasce de `main`, volta pra `main` **e** `development`.
+- Commits seguem Conventional Commits (`feat:`, `fix:`, `BREAKING CHANGE:`) —
+  ver issue #74 e `docs/CONVENTIONS.md` seção 11 para o fluxo completo.
+- Versão se marca com tag, gerada na branch `release/*`.
+- **Nunca** `git reset --hard` ou `push --force` em `development` ou `main`.
+- **Não commite sem o Pedro pedir explicitamente.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**ARCA** is a psychology clinic management system (Brazilian Portuguese UI) built as a Turborepo monorepo with two apps:
+**ARCA** is a multi-tenant psychology clinic management SaaS (Brazilian Portuguese UI) built as a Turborepo monorepo with two apps:
 
 - `apps/backend` — NestJS REST API on port 3333
-- `apps/frontend` — Next.js 15 web app on port 3000
+- `apps/frontend` — Next.js 15 web app on port 3000, currently under active rebuild
 
-Domain: patient waitlist, therapy sessions (atendimentos), medical records (prontuários), audit logging, and role-based access for estagiários (interns) and supervisors.
+Domain: patient waitlist, therapy sessions (atendimentos), medical records (prontuários), audit logging, and role-based access for estagiários (interns) and supervisors. This originated as an academic thesis project but is now developed as a commercial product (co-founded at WizeCode) — treat technical decisions as production-grade, not academic-scope.
 
 ## Commands
 
@@ -56,7 +56,7 @@ npx prisma generate               # Regenerate Prisma client
 Standard NestJS modular architecture. Each domain is a self-contained module in `apps/backend/src/`:
 
 | Module            | Purpose                                                   |
-| ----------------- | --------------------------------------------------------- |
+| ------------------ | --------------------------------------------------------- |
 | `auth/`           | JWT + Local strategies, Passport guards, login endpoint   |
 | `users/`          | User CRUD (estagiários/supervisors)                       |
 | `waitlist/`       | Patient waiting list (lista de espera)                    |
@@ -74,6 +74,8 @@ Standard NestJS modular architecture. Each domain is a self-contained module in 
 - Role-based access controlled via `roleId` on `Usuario` model
 - Medical record `conteudo` field is encrypted at rest using `CryptoService`
 
+**Domain entities (planned, not yet in codebase):** the intended direction is to move business logic out of services operating on raw Prisma types and into rich domain classes (e.g. `Atendimento`, `Prontuario`) with factory methods (`fromPrisma()`, `fromJSON()`). Prisma models stay data-only. As of the last audit, this pattern hasn't landed in `apps/backend/src` yet — check before assuming it's implemented. A shared `packages/domain` Turborepo package is the candidate home for this once it exists on both frontend and backend.
+
 **Medical record types** (DTOs in `medical_record/dto/`):
 
 - `triagem` — initial triage record
@@ -81,44 +83,67 @@ Standard NestJS modular architecture. Each domain is a self-contained module in 
 - `alta` — discharge report
 - `encaminhamento` — referral
 
-### Frontend (Next.js 15 App Router)
+### Frontend (Next.js 15 App Router) — actively being rebuilt from scratch
 
-Authentication uses **NextAuth v4** with a Credentials provider that calls the backend `/auth/login` endpoint. The JWT token from the backend is stored in the NextAuth session.
+The pre-rebuild frontend (last state at commit `2c62150476c92fdabc61459f2bca6f691bc7965b`) is kept **only as a business-logic reference** — its routes and components below are historical, not current.
 
-- `middleware.ts` — protects `/dashboard/*` routes, enforces role-based redirects
-- `lib/api.ts` — Axios instance that automatically injects `Authorization: Bearer {token}` from NextAuth session
-- `app/api/auth/[...nextauth]/route.ts` — NextAuth handler
-- `components/ui/` — shadcn/ui components (new-york style, neutral base, lucide icons)
+**Locked-in architecture decisions for the rebuild:**
 
-**Auth flow:** Login form → NextAuth CredentialsProvider → backend `/auth/login` → JWT stored in session → Axios interceptor adds token to all API calls.
+- Server Actions for all data fetching/mutations (no client-side data-fetching hooks hitting the backend directly)
+- Route Handlers used exclusively for NextAuth (`app/api/auth/[...nextauth]/route.ts`)
+- No `NEXT_PUBLIC_` env vars except what NextAuth itself requires
+- Authenticated app lives under `/plataforma/*`
+- Route groups: `(auth)` for authenticated routes, `(external)` for public routes
 
-**Route structure:**
+**Current structure (as of last audit):**
 
 ```
 app/
-├── login/                          # Public login page
-├── lista-espera/
-│   ├── cadastro/                   # Public patient self-registration
-│   └── consulta/                   # Public waitlist position check
-└── dashboard/                      # All protected (requires auth)
-    ├── agenda/                     # Calendar view
-    ├── atendimento/
-    │   └── cadastro/               # Create new session
-    ├── auditoria/                  # Audit logs viewer
-    ├── fluxo-atendimento/          # Session workflow
-    ├── lista-espera/               # Waitlist management
-    │   └── cadastro/
-    ├── pacientes/[id]/             # Patient detail
-    ├── perfil/                     # User profile
-    ├── relatorios/
-    │   ├── psicoterapia/[id]/      # Psychotherapy report (edit, aprovar)
-    │   └── triagem/[id]/           # Triage report (edit, aprovar)
-    ├── unauthorized/               # Access denied page
-    └── usuarios/
-        └── cadastro/               # Create user
+├── (auth)/
+│   ├── layout.tsx
+│   ├── login/
+│   └── plataforma/
+│       ├── layout.tsx     # Sidebar shell, role-based nav filtering
+│       └── page.tsx       # Dashboard — currently a skeleton/placeholder
+├── (external)/            # Public routes
+├── api/
+│   └── auth/[...nextauth]/route.ts
+└── globals.css
 ```
 
-**Auth components** (`components/auth/`):
+Only the platform shell exists so far (sidebar, route-protection middleware, empty dashboard). No domain modules (pacientes, atendimentos, waitlist, etc.) have been migrated into the new structure yet — that work is tracked incrementally via GitHub milestones M0–M12, one `feat:` issue per module. Check open issues/milestones for what's next rather than assuming from this file.
+
+Authentication uses **NextAuth v4** with a Credentials provider that calls the backend `/auth/login` endpoint. The JWT token from the backend is stored in the NextAuth session.
+
+- `middleware.ts` — protects `/plataforma/*` routes, enforces role-based redirects
+- `components/ui/` — shadcn/ui components (new-york style, neutral base, lucide icons)
+
+**Auth flow:** Login form → NextAuth CredentialsProvider → backend `/auth/login` → JWT stored in session → Server Actions read the session server-side to authenticate backend calls.
+
+**Historical route structure (pre-rebuild, reference only — do not build against this):**
+
+```
+app/
+├── login/
+├── lista-espera/
+│   ├── cadastro/
+│   └── consulta/
+└── dashboard/                       # superseded by /plataforma
+    ├── agenda/
+    ├── atendimento/cadastro/
+    ├── auditoria/
+    ├── fluxo-atendimento/
+    ├── lista-espera/cadastro/
+    ├── pacientes/[id]/
+    ├── perfil/
+    ├── relatorios/
+    │   ├── psicoterapia/[id]/
+    │   └── triagem/[id]/
+    ├── unauthorized/
+    └── usuarios/cadastro/
+```
+
+**Auth components** (`components/auth/`, pre-rebuild reference):
 
 - `ConditionalRender.tsx` — renders children only if user has required role
 - `ProtectedRoute.tsx` — client-side route guard
@@ -155,7 +180,7 @@ Understanding this flow is essential — the entire system models it:
 Four roles with decreasing privileges (stored as `roleId` on `Usuario`):
 
 | Role         | PT Name     | Key Permissions                                                                    |
-| ------------ | ----------- | ---------------------------------------------------------------------------------- |
+| ------------ | ----------- | ------------------------------------------------------------------------------------ |
 | `ADMIN`      | Coordenador | Full access including audit logs, fluxo-atendimento dashboard, user management     |
 | `SECRETARIO` | Secretário  | Schedule sessions, manage waitlist, view fluxo-atendimento, manage patients        |
 | `SUPERVISOR` | Supervisor  | Approve/reject intern reports, generate alta/encaminhamento, see own patients only |
@@ -163,11 +188,12 @@ Four roles with decreasing privileges (stored as `roleId` on `Usuario`):
 
 Critical access rules:
 
-- **Audit logs** (`/dashboard/auditoria`): Coordinator only
-- **Fluxo de atendimento** (`/dashboard/fluxo-atendimento`): Coordinator + Secretary only
+- **Audit logs**: Coordinator only
+- **Fluxo de atendimento**: Coordinator + Secretary only
 - **Patient visibility**: Coordinator/Secretary see all patients; Supervisor/Estagiário see only their assigned patients
 - **User creation**: A user can only create users with a role equal to or lower than their own
 - **Waitlist**: All internal roles can read/edit; public can self-register and check position
+- **Multi-tenancy**: no authenticated user should be able to reach another tenant's resources by substituting an ID — this is the highest-priority security gap to keep re-verifying (BOLA) as new endpoints are built
 
 ### Regulatory Context
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-# ARCA - Sistema de Gestão para Clínica de Psicologia
+# ARCA - Sistema de Gestão para Clínicas de Psicologia
 
-Sistema completo de gestão para clínicas de psicologia, desenvolvido como projeto de conclusão de curso. O ARCA facilita o gerenciamento de pacientes, atendimentos, documentos e relatórios, oferecendo controle de acesso baseado em funções e auditoria completa das operações.
+Plataforma SaaS multi-tenant de gestão para clínicas de psicologia. O ARCA facilita o gerenciamento de pacientes, atendimentos, documentos e relatórios, oferecendo controle de acesso baseado em funções, auditoria completa das operações e isolamento de dados entre clínicas (tenants).
 
 ## 🎯 Visão Geral
 
-O sistema ARCA (Ambiente de Registro e Controle de Atendimentos) é uma solução full-stack projetada para otimizar a gestão de clínicas de psicologia, proporcionando:
+O sistema ARCA (Ambiente de Registro e Controle de Atendimentos) é uma solução full-stack multi-tenant projetada para atender múltiplas clínicas de psicologia de forma isolada e segura, proporcionando:
 
+- **Multi-tenant**: Isolamento completo de dados entre clínicas distintas
 - **Gestão de Pacientes**: Cadastro completo com dados pessoais e histórico
 - **Lista de Espera**: Controle de candidatos aguardando atendimento
 - **Agendamento**: Sistema de marcação e controle de consultas
@@ -13,6 +14,10 @@ O sistema ARCA (Ambiente de Registro e Controle de Atendimentos) é uma soluçã
 - **Relatórios**: Geração de relatórios de alta e acompanhamento
 - **Auditoria**: Log completo de todas as operações realizadas
 - **Controle de Acesso**: Sistema de roles para estagiários e supervisores
+
+### Status Atual
+
+O backend está estabilizado (segurança, RBAC, auditoria, testes). O frontend está em reconstrução ativa a partir do zero — a estrutura antiga (pré-reescrita) segue apenas como referência de regras de negócio, não como fonte de verdade. Ver `CLAUDE.md` para detalhes de arquitetura atualizados.
 
 ## 🏗️ Arquitetura
 
@@ -28,7 +33,7 @@ Este é um monorepo gerenciado pelo [Turborepo](https://turborepo.org/) contendo
 - **Backend**: NestJS, Prisma ORM, PostgreSQL
 - **Frontend**: Next.js 15, React 19, TypeScript, TailwindCSS
 - **Desenvolvimento**: TypeScript, ESLint, Prettier
-- **Deploy**: Preparado para containerização com Docker
+- **Deploy**: Docker + Coolify (CD automático)
 
 ## 🚀 Início Rápido
 
@@ -41,41 +46,36 @@ Este é um monorepo gerenciado pelo [Turborepo](https://turborepo.org/) contendo
 ### Instalação
 
 1. **Clone o repositório**
-
    ```bash
    git clone https://github.com/pedrokourly/arca.git
    cd arca
    ```
 
 2. **Instale as dependências**
-
    ```bash
    npm install
    ```
 
 3. **Configure o banco de dados**
-
    ```bash
    # Crie um arquivo .env no diretório backend
    cp apps/backend/.env.example apps/backend/.env
-
+   
    # Configure a string de conexão do PostgreSQL
    DATABASE_URL="postgresql://usuario:senha@localhost:5432/arca_db"
    ```
 
 4. **Execute as migrações**
-
    ```bash
    cd apps/backend
    npx prisma migrate dev
    ```
 
 5. **Inicie o desenvolvimento**
-
    ```bash
    # Volta para a raiz do projeto
    cd ../..
-
+   
    # Inicia backend (porta 3333) e frontend (porta 3000) simultaneamente
    npm run dev
    ```
@@ -89,34 +89,29 @@ Este é um monorepo gerenciado pelo [Turborepo](https://turborepo.org/) contendo
 ## 📋 Funcionalidades
 
 ### Gestão de Usuários
-
 - Cadastro de estagiários e supervisores
 - Controle de acesso baseado em roles
 - Autenticação segura
 
 ### Gestão de Pacientes
-
 - Cadastro completo com dados demográficos
 - Histórico de atendimentos
 - Relatórios de progresso
 - Lista de espera organizada
 
 ### Sistema de Atendimentos
-
 - Agendamento de consultas
 - Registro de observações
 - Status de acompanhamento
 - Histórico completo
 
 ### Documentação
-
 - Upload de arquivos
 - Versionamento de documentos
 - Relatórios de alta
 - Controle de acesso aos documentos
 
 ### Auditoria e Compliance
-
 - Log de todas as operações
 - Rastreabilidade completa
 - Relatórios de auditoria
@@ -159,15 +154,13 @@ arca/
 │   │   │   ├── schema.prisma # Schema do banco de dados
 │   │   │   └── migrations/   # Migrações do banco
 │   │   └── package.json
-│   └── frontend/             # Interface Next.js
-│       ├── src/
-│       │   ├── app/         # App Router
-│       │   ├── components/  # Componentes React
-│       │   ├── contexts/    # Contextos React
-│       │   ├── hooks/       # Custom hooks
-│       │   └── lib/         # Utilitários
+│   └── frontend/             # Interface Next.js (em reconstrução)
+│       ├── app/
+│       │   ├── (auth)/       # Rotas autenticadas, incl. /plataforma
+│       │   ├── (external)/   # Rotas públicas
+│       │   └── api/          # Route Handlers (NextAuth)
 │       └── package.json
-├── packages/                 # Packages compartilhados (futuro)
+├── packages/                 # Packages compartilhados (futuro: domain)
 ├── turbo.json               # Configuração Turborepo
 └── package.json             # Configuração raiz
 ```
@@ -185,21 +178,18 @@ O sistema utiliza um modelo relacional robusto com as seguintes entidades princi
 
 ## 🔒 Segurança e Compliance
 
-- Autenticação baseada em JWT
-- Controle de acesso granular por roles
+- Autenticação baseada em JWT (audience/issuer validados)
+- Controle de acesso granular por roles (RBAC)
 - Criptografia de senhas com hash seguro
 - Logs de auditoria para compliance
 - Validação de dados em múltiplas camadas
-- Preparado para conformidade com LGPD
+- Conformidade com LGPD
 
 ## 🚢 Deploy
 
-O projeto está preparado para deploy com:
-
-- **Docker**: Containerização para fácil deploy
-- **Vercel**: Frontend Next.js
-- **Railway/Heroku**: Backend NestJS
-- **Supabase/Neon**: PostgreSQL gerenciado
+- **Coolify**: CD com deploy automático a cada push (backend e frontend)
+- **Supabase**: PostgreSQL gerenciado
+- **Docker**: Containerização para build e deploy
 
 ## 🤝 Contribuição
 
@@ -215,7 +205,7 @@ Este projeto é licenciado sob a MIT License - veja o arquivo [LICENSE](LICENSE)
 
 ## 👥 Equipe
 
-Desenvolvido como projeto de TCC por Pedro Kourly
+Desenvolvido por Pedro Kourly.
 
 ---
 

--- a/docs/ARQUITETURA.md
+++ b/docs/ARQUITETURA.md
@@ -1,0 +1,152 @@
+# Arquitetura do ARCA
+
+Este documento é o mapa único do projeto: o que é, como está construído, o que já existe e o que falta. Se você está chegando agora — como colaborador ou voltando depois de um tempo parado — comece por aqui, não pelo Swagger. O Swagger mostra os endpoints; este documento mostra por que eles existem e como se encaixam.
+
+Documentação relacionada:
+- `README.md` — como instalar e rodar o projeto localmente
+- `CLAUDE.md` — referência técnica rápida para sessões de desenvolvimento assistido (comandos, estrutura de pastas)
+- `docs/adr/` — o histórico de decisões de arquitetura, uma por arquivo, nunca reescritas (só substituídas por uma ADR nova quando a decisão muda)
+
+## 1. O que é o ARCA
+
+Uma plataforma SaaS multi-tenant de gestão para clínicas de psicologia — cadastro de pacientes, fluxo clínico completo (triagem → psicoterapia → alta), documentação com validade regulatória (CFP 06/2019), auditoria e conformidade com LGPD. Múltiplas clínicas usam a mesma plataforma, com dados isolados entre elas.
+
+Nasceu como TCC, mas é tratado como produto comercial real desde então — decisões técnicas seguem padrão de produção, não escopo acadêmico.
+
+## 2. Stack e por que essas escolhas
+
+| Camada | Tecnologia | Por quê |
+|---|---|---|
+| Backend | NestJS + Prisma + PostgreSQL | Tipagem forte ponta a ponta, migrations versionadas, estrutura modular que escala bem pra um time pequeno |
+| Frontend | Next.js 15 (App Router) + Server Actions | Sem camada de API intermediária no frontend — Server Actions falam direto com o backend, menos código de integração pra manter |
+| Monorepo | Turborepo | Backend e frontend num repo só, cache de build compartilhado |
+| Auth | Passport.js + JWT (backend) / NextAuth v4 (frontend) | JWT com audience/issuer validados; sessão do frontend guarda o token e injeta em toda chamada |
+| Deploy | Coolify + Supabase | CD automático a cada push, banco gerenciado — sem precisar operar infraestrutura própria como dev solo |
+
+## 3. Como as peças se encaixam
+
+```
+Usuário → Next.js (Server Actions) → NestJS API → Prisma → PostgreSQL (Supabase)
+                ↓
+           NextAuth (sessão, JWT)
+```
+
+Decisões travadas para o frontend (detalhe completo no `CLAUDE.md`):
+- Toda leitura/escrita de dado passa por Server Action, nunca por hook client-side batendo direto na API
+- Route Handlers existem só para o NextAuth
+- Nenhuma env var `NEXT_PUBLIC_` além do que o NextAuth exige
+- App autenticado vive em `/plataforma/*`, dentro do route group `(auth)`; rotas públicas ficam em `(external)`
+
+## 4. Modelo de domínio
+
+O diagrama abaixo é o núcleo relacional do sistema. Os campos `id_Clinica` marcados representam o estado **planejado** (ver ADR 0001) — ainda não implementados no banco atual.
+
+```mermaid
+erDiagram
+  CLINICA ||--o{ USUARIO : emprega
+  CLINICA ||--o{ LISTA_ESPERA : atende
+  CLINICA ||--o{ ATENDIMENTO : realiza
+  CLINICA ||--o{ PRONTUARIO : registra
+  CLINICA ||--o{ LOG_AUDITORIA : audita
+  ROLE ||--o{ USUARIO : define
+  LISTA_ESPERA ||--o{ ATENDIMENTO : origina
+  ATENDIMENTO ||--o{ PRONTUARIO : gera
+  USUARIO ||--o{ LOG_AUDITORIA : executa
+
+  CLINICA {
+    uuid id_Clinica PK
+    string nome
+    string slug
+    boolean isActive
+  }
+  USUARIO {
+    uuid id_User PK
+    uuid id_Clinica FK
+    string nome
+    string email
+    int roleId FK
+    string CRP
+  }
+  ROLE {
+    int id_Role PK
+    string role
+  }
+  LISTA_ESPERA {
+    uuid id_Lista PK
+    uuid id_Clinica FK
+    string nomeRegistro
+    string CPF
+    int id_Status FK
+  }
+  ATENDIMENTO {
+    uuid id_Atendimento PK
+    uuid id_Clinica FK
+    uuid id_Lista FK
+    uuid id_Estagiario_Executor FK
+    uuid id_Supervisor_Executor FK
+    int id_Status FK
+  }
+  PRONTUARIO {
+    uuid id_Registro PK
+    uuid id_Clinica FK
+    uuid id_Atendimento FK
+    string conteudo
+    int id_Tipo FK
+  }
+  LOG_AUDITORIA {
+    uuid id_Log PK
+    uuid id_Clinica FK
+    uuid id_Usuario_Executor FK
+    string tipoAcao
+  }
+```
+
+Fora do diagrama por clareza: tabelas de apoio globais (`Genero`, `Etnia`, `Escolaridade`, `StatusListaEspera`, `StatusAtendimento`, `TipoAtendimento`, `StatusProntuario`, `TipoProntuario`) — são lookups compartilhados entre todas as clínicas, não têm `id_Clinica`.
+
+### Fluxo clínico (o que o sistema modela)
+
+1. **Em Espera** — paciente se autocadastra publicamente, recebe UUID pra consultar posição
+2. **Em Triagem** — secretário agenda sessão de triagem; estagiário preenche o relatório; supervisor aprova
+3. **Aguardando Psicoterapia** — aprovado, esperando vaga
+4. **Em Psicoterapia** — sessões recorrentes, evolução registrada e aprovada a cada sessão
+5. **Alta / Encaminhado** — documento final gerado, paciente sai do sistema
+
+### Papéis
+
+| Papel | Acesso |
+|---|---|
+| Coordenador (ADMIN) | Tudo, incluindo auditoria e gestão de usuários |
+| Secretário | Agendamento, lista de espera, visão de fluxo completo |
+| Supervisor | Aprova relatórios de estagiários, gera documentos finais, vê só seus pacientes |
+| Estagiário | Preenche relatórios, vê só seus pacientes |
+
+## 5. Status atual
+
+| Área | Status | Observação |
+|---|---|---|
+| Backend — módulos core | ✅ Pronto | auth, users, waitlist, session, medical_record, audit, crypto, pdf |
+| Backend — segurança base | ✅ Pronto | RBAC, rate limiting, helmet, JWT audience/issuer, auditoria global |
+| Backend — multi-tenancy (schema) | 🔜 Planejado | ADR 0001 — issue aberta, ainda não implementado |
+| Backend — enforcement de tenant + RLS | 🔜 Planejado | Depende do item acima |
+| Backend — entidades de domínio ricas | 🔜 Planejado | Direção decidida (`Atendimento`, `Prontuario` com `fromPrisma()`), ainda não no código |
+| Frontend — shell da plataforma | ✅ Pronto | Sidebar, proteção de rota, dashboard vazio em `/plataforma` |
+| Frontend — módulos de domínio | ⏳ Não iniciado | Pacientes, atendimentos, waitlist etc. — tracked via milestones M0–M12 no GitHub |
+| Documentação viva (ADRs) | 🟡 Começando | ADR 0001 é a primeira; adicionar ao repo em `docs/adr/` |
+
+## 6. Decisões arquiteturais (ADRs)
+
+Um ADR (Architecture Decision Record) registra **uma** decisão: o contexto que levou a ela, a decisão em si, e as consequências — inclusive as negativas. Nunca é editado depois de aceito; se a decisão muda, escreve-se um novo ADR que supera o anterior.
+
+Ficam em `docs/adr/`, um arquivo por decisão, numerados em ordem (`0001-`, `0002-`...). Existentes:
+
+- `0001-multi-tenancy-estrategia-hibrida.md` — banco único compartilhado com `clinicaId`, ao invés de um banco por clínica
+
+Quando surgir uma dúvida do tipo "por que decidimos X" no futuro, a resposta deve estar aqui, não na memória de ninguém.
+
+## 7. Pra quem está chegando agora
+
+1. Leia este documento inteiro antes de tocar em código
+2. Rode o projeto localmente seguindo o `README.md`
+3. Veja as issues abertas no GitHub com o milestone atual — é o backlog priorizado
+4. Convenções a seguir: identificadores de código em inglês, texto voltado ao usuário em português; Server Actions para toda integração com o backend no frontend; nenhuma lógica de negócio direto num controller — isso vai migrar para classes de domínio conforme a Seção 5 indica
+5. Dúvida de arquitetura que este documento não responde? Provavelmente falta um ADR — é sinal de escrever um, não de perguntar de novo daqui a três meses

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,0 +1,342 @@
+# Convenções de Componentes e Versionamento
+
+> Como estruturamos componentes, páginas e o fluxo de release neste projeto — e
+> por quê. Adaptado do padrão usado no site institucional da WizeCode para o
+> contexto do ARCA (SaaS de dado dinâmico, não site de conteúdo). Leia antes de
+> criar um componente novo, uma página nova, ou abrir um PR.
+
+Documentação relacionada: `CLAUDE.md` (referência técnica — comandos, módulos,
+env vars), `docs/ARQUITETURA.md` (visão geral do sistema), `docs/adr/` (decisões
+de arquitetura já tomadas).
+
+---
+
+## 1. O princípio central — com uma diferença importante do site
+
+No site institucional, "conteúdo" é só texto de marketing, e ele é sempre
+estático. No ARCA, existem **dois tipos de conteúdo**, e a regra muda pra cada
+um:
+
+| Tipo | Exemplo | Onde mora |
+|---|---|---|
+| **Copy estático de UI** | Título da página, texto de empty state, label de botão | `[modulo].data.ts`, igual ao site |
+| **Dado dinâmico de aplicação** | Paciente, atendimento, prontuário, lista de espera | Vem via Server Action, nunca em `.data.ts` |
+
+Confundir os dois é o erro mais fácil de cometer vindo do padrão do site — lá,
+tudo que aparece na tela é conteúdo estático. Aqui, a maior parte da tela é dado
+vivo do banco.
+
+A mentalidade que continua igual: **um componente é uma função que você chama,
+não um template que você edita.** Se você abrir um componente pra trocar um
+texto fixo, ele virou template — o sintoma clássico do shadcn/ui quando alguém
+edita o valor padrão em vez de passar por prop.
+
+```tsx
+// ❌ Copy fixo dentro do componente
+const EmptyState = () => <p>Nenhum paciente na lista de espera</p>
+
+// ✅ Copy vem de fora — de um .data.ts, não do componente
+const EmptyState = ({ title }: EmptyStateProps) => <p>{title}</p>
+```
+
+---
+
+## 2. A linha entre copy estático, dado dinâmico e componente
+
+| Vai para `[modulo].data.ts` (copy estático) | Vem de Server Action (dado dinâmico) | Fica no componente (estrutura) |
+|---|---|---|
+| Título da página, subtítulos | Lista de pacientes, atendimentos | Arranjo/layout (`flex`, `grid`) |
+| Texto de empty state | Status de um atendimento | Tipografia e espaçamento do esqueleto |
+| Label de botão, placeholder de campo | Conteúdo de um prontuário | Animações e transições |
+| Texto de confirmação/erro genérico | Resultado de uma busca/filtro | Comportamento (ex: qual aba está ativa) |
+
+**Casos de borda:**
+
+- **Mensagem de validação de formulário** (`"CPF inválido"`) é copy estático →
+  `.data.ts` ou schema do Zod, nunca hardcoded no componente de campo.
+- **Nome do paciente exibido no header do prontuário** é dado dinâmico → vem via
+  prop, alimentada por Server Action, nunca por `.data.ts`.
+- **A cor de um badge de status** (`Em Triagem` = amarelo) é regra de negócio,
+  não copy nem dado do backend → fica no componente, como mapeamento
+  `status → variant` do `cva()` (seção 5).
+
+Regra de bolso: **se pode mudar sem redeploy, é dado dinâmico. Se só muda quando
+alguém edita o código, é copy estático.**
+
+---
+
+## 3. Props obrigatórias, sem valor padrão
+
+Componentes de layout, template e sheet **não** definem default de conteúdo. Só
+prop de **variação de layout** pode ter default.
+
+```tsx
+// ❌ Default esconde erro de integração — a página esqueceu de passar o nome
+interface PatientHeaderProps {
+  nome?: string
+}
+const PatientHeader = ({ nome = "Paciente" }: PatientHeaderProps) => ...
+
+// ✅ Obrigatória — se a Server Action falhar em popular isso, o TS reclama
+interface PatientHeaderProps {
+  nome: string
+  variant?: "compact" | "full"   // ok: default de layout
+}
+const PatientHeader = ({ nome, variant = "full" }: PatientHeaderProps) => ...
+```
+
+---
+
+## 4. Onde o copy estático mora: `[modulo].data.ts`
+
+Todo copy estático de uma rota vive num módulo co-localizado — sem exceção de
+tamanho, mesmo um título de uma linha.
+
+```text
+app/(auth)/plataforma/
+  lista-espera/
+    page.tsx                 ← compõe a página
+    lista-espera.data.ts     ← copy estático desta rota (títulos, empty state)
+    patient-row.tsx          ← componente específico deste módulo
+```
+
+```ts
+// lista-espera.data.ts — só copy, nunca dado de paciente
+export const listaEspera = {
+  titulo: "Lista de Espera",
+  emptyState: {
+    titulo: "Nenhum paciente aguardando",
+    descricao: "Cadastros públicos aparecem aqui automaticamente.",
+  },
+  botaoNovo: "Adicionar à lista",
+}
+```
+
+```tsx
+// page.tsx — busca dado dinâmico via Server Action, injeta copy do .data.ts
+import { listaEspera } from "./lista-espera.data"
+import { getListaEspera } from "./actions"
+
+export default async function Page() {
+  const pacientes = await getListaEspera()   // dado dinâmico, direto do backend
+
+  return (
+    <ListPage
+      title={listaEspera.titulo}             // copy estático
+      data={pacientes}                       // dado dinâmico
+      emptyState={listaEspera.emptyState}
+    />
+  )
+}
+```
+
+Ícone referenciado em copy estático segue registro central (`lib/icons.ts`),
+igual ao site — nunca importe o componente de ícone direto no `.data.ts`, porque
+Server → Client não passa função/JSX pela fronteira.
+
+---
+
+## 5. Variante ou componente novo? O teste do CVA
+
+> **Se a variação cabe num `cva()`, é variante. Se muda a árvore HTML, é
+> componente novo.**
+
+```tsx
+// StatusBadge — cabe no CVA: só muda cor/fundo por status
+const statusVariants = cva("rounded-full px-2 py-0.5 text-xs font-medium", {
+  variants: {
+    status: {
+      em_espera: "bg-muted text-muted-foreground",
+      em_triagem: "bg-amber-100 text-amber-800",
+      em_psicoterapia: "bg-blue-100 text-blue-800",
+      alta: "bg-green-100 text-green-800",
+    },
+  },
+})
+```
+
+Se a variante muda a árvore — por exemplo, um cartão de paciente que em um
+contexto mostra ações (editar, arquivar) e em outro não — não force isso num
+`cva()` com `if` escondido. São dois componentes: `PatientCard` e
+`PatientCardCompact`, compartilhando o miolo se fizer sentido.
+
+Use `cva()` + `VariantProps` (não digite a união à mão) e componha com `cn()`.
+**Nunca `!important`.**
+
+---
+
+## 6. Estrutura de arquivos
+
+```text
+components/
+  ui/            ← primitivos shadcn/ui (não editar por conteúdo)
+  layout/        ← só chrome GLOBAL: sidebar, header, shell de proteção de rota
+  forms/
+    fields/              ← primitivos de campo compartilhados
+    form-layout.tsx      ← espaçamento comum a todo formulário
+    form-[nome].tsx      ← formulários concretos (cadastro-paciente, triagem...)
+  sheets/
+    sheet-[nome].tsx     ← modais de ação (SheetAgendarSessao etc.)
+  templates/
+    list-page.tsx        ← título + filtro + tabela + paginação
+    detail-page.tsx       ← header do registro + abas
+  shared/        ← só o que já foi usado em 2+ módulos — nunca cria aqui de saída
+
+app/(auth)/plataforma/
+  pacientes/
+    page.tsx
+    patient-header.tsx    ← específico deste módulo, colocado aqui
+    pacientes.data.ts
+  atendimentos/
+    page.tsx
+    atendimento-card.tsx
+    atendimentos.data.ts
+```
+
+**A regra de cada gaveta:**
+
+- `ui/` — primitivos shadcn, intocados por conteúdo.
+- `layout/` — só o que serve **qualquer** página autenticada. Se um componente
+  só faz sentido em um módulo, ele não é layout.
+- `forms/` — campos e espaçamento centralizados; cada formulário concreto tem
+  validação própria (Zod), mas nenhum redefine espaçamento na mão.
+- `sheets/` — ação que abre sobre a página atual em vez de navegar pra uma rota
+  nova. É o padrão preferido do ARCA para criar/editar (ex: `SheetAgendarSessao`
+  no lugar de `/atendimento/cadastro`).
+- `templates/` — os dois formatos de página que já se repetem no fluxo clínico
+  (ver seção 7). Predefinidos agora porque o formato já existe, testado, no
+  frontend antigo (commit `2c62150476c92fdabc61459f2bca6f691bc7965b`) — não é
+  abstração adivinhada.
+- `shared/` — promoção, não ponto de partida. Um componente nasce dentro do
+  módulo (`app/**/[modulo]/`); só sobe pra cá quando um **segundo** módulo
+  precisa dele de verdade.
+
+---
+
+## 7. Os dois templates
+
+```tsx
+// components/templates/list-page.tsx
+/** Título + ação + filtro + tabela + paginação. Usa em qualquer módulo de listagem. */
+interface ListPageProps<T> {
+  title: string
+  actions?: React.ReactNode        // ex: botão que abre um Sheet de criação
+  filters?: React.ReactNode        // barra de filtro, específica de cada módulo
+  columns: ColumnDef<T>[]
+  data: T[]
+  emptyState?: { titulo: string; descricao: string }
+}
+```
+
+```tsx
+// components/templates/detail-page.tsx
+/** Header do registro + abas de conteúdo. Usa em qualquer módulo de detalhe. */
+interface DetailPageProps {
+  header: React.ReactNode          // resumo do registro (paciente, atendimento...)
+  tabs: { label: string; content: React.ReactNode }[]
+  actions?: React.ReactNode        // ex: "Gerar Alta" — abre Sheet ou Server Action
+}
+```
+
+Uso mapeado:
+
+| Template | Módulos |
+|---|---|
+| `ListPage` | Lista de Espera, Agenda, Atendimentos, Pacientes, Admin/Usuários |
+| `DetailPage` | Paciente, Atendimento, Prontuário |
+
+---
+
+## 8. Idioma e comentários
+
+- **Inglês:** nome de arquivo, componente, prop, variável, função, comentário.
+- **Português:** rota e todo copy/conteúdo voltado ao usuário — igual ao que já
+  está em `CLAUDE.md`.
+- **Comentários curtos.** Não explique o óbvio; comente restrição e motivo.
+  JSDoc no topo de templates, sheets e componentes de módulo complexos.
+
+---
+
+## 9. Ordem de classes Tailwind
+
+Automática via `prettier-plugin-tailwindcss` (adicionar ao projeto se ainda não
+estiver configurado, com `cn`/`cva` em `tailwindFunctions`). Ninguém ordena
+classe na mão; `npm run format` resolve.
+
+---
+
+## 10. Fronteiras com fornecedores (analytics, flags)
+
+Mesma regra do site, com stakes maiores aqui: **fornecedor de infraestrutura
+nunca é importado direto numa página ou componente.** Sempre atrás de uma
+interface que o app define, em `lib/`.
+
+```text
+lib/analytics/
+  types.ts             ← contrato: Analytics.track(event, props)
+  adapters/posthog.ts  ← traduz track() → posthog.capture()
+  index.ts             ← escolhe o adaptador
+```
+
+No site isso é sobre não travar em um vendor. No ARCA é sobre **compliance**:
+se o PostHog (avaliado em março para session replay) entrar em produção, essa
+interface é o único lugar que decide o que é enviado pra fora — nenhum
+componente que renderiza dado de prontuário deve saber que analytics existe.
+ESLint barra `posthog-js` fora de `lib/analytics/adapters/` e do provider de
+boot, igual ao site.
+
+---
+
+## 11. Fluxo de Git e versionamento
+
+Duas diferenças em relação ao site: o ARCA **é** produto versionado (então usa
+`release/*`, que o site deliberadamente não usa), e o versionamento é
+automatizado via Conventional Commits — retomando a proposta já aberta na
+[issue #74](https://github.com/pedrokourly/arca/issues/74).
+
+| Merge | Como | Por quê |
+|---|---|---|
+| `feature/*` / `fix/*` → `development` | PR com **squash** | Cada feature vira um commit limpo |
+| `development` → `release/x.y.z` | Branch nova, quando pronto pra congelar | Estabiliza enquanto `development` segue pra próxima versão |
+| `release/*` → `main` | PR com **merge normal** (nunca squash) | Preserva ancestralidade — squash aqui gera conflito `add/add` no ciclo seguinte |
+| `release/*` → `development` | PR com **merge normal** | Sincroniza a versão e o changelog gerados de volta pra `development` |
+| `hotfix/*` → `main` **e** `development` | PR em cada uma | A correção precisa existir nas duas |
+
+**Regras:**
+
+- Nada de commit direto em `main` ou `development`. Sempre PR, sempre revisado.
+- `feature/*`/`fix/*` nascem de `development`. `hotfix/*` nasce de `main`.
+- Branch pequena e de vida curta.
+- **Nunca** `reset --hard` / `push --force` em `development` ou `main`.
+
+**Versionamento automático (na branch `release/*`):**
+
+1. Commits seguem Conventional Commits (`feat:`, `fix:`, `BREAKING CHANGE:`),
+   validados por `commitlint` + hook do `husky`
+2. `commitizen` guia a escrita da mensagem (`npm run commit`)
+3. Na `release/*`, rodar a ferramenta de release (`standard-version` ou
+   `release-it`): analisa os commits desde a última tag, faz bump de versão
+   (`patch`/`minor`/`major`), atualiza `CHANGELOG.md`, cria a tag
+4. Versão é única pro monorepo inteiro (backend + frontend juntos), marcada no
+   `package.json` raiz — não versiona os dois apps separadamente
+
+| Tipo de commit | Impacto na versão |
+|---|---|
+| `fix` | patch |
+| `feat` | minor |
+| `BREAKING CHANGE` | major |
+| `chore`, `docs`, `refactor`, `test` | nenhum |
+
+---
+
+## Checklist de code review
+
+- [ ] Copy estático está em `[modulo].data.ts`; dado dinâmico vem de Server Action
+- [ ] Props de conteúdo são obrigatórias; só prop de layout tem default
+- [ ] Variante cabe num `cva()`. Se muda a árvore HTML, é componente novo
+- [ ] Componente está na gaveta certa — e só está em `shared/` se um 2º módulo já usa
+- [ ] `page.tsx` lê como composição, não tem lógica de negócio embutida
+- [ ] Código/props/comentários em inglês; copy e rotas em português
+- [ ] Fornecedor de analytics não é importado direto na UI
+- [ ] Mensagem de commit segue Conventional Commits
+- [ ] PR segue o fluxo da seção 11 (squash pra `development`, merge normal daí pra frente)

--- a/docs/adr/0001-multi-tenancy-estrategia-hibrida.md
+++ b/docs/adr/0001-multi-tenancy-estrategia-hibrida.md
@@ -1,0 +1,45 @@
+# ADR 0001: Estratégia de Multi-tenancy — Isolamento no Schema Agora, Features Depois
+
+**Status:** Aceito
+**Data:** 2026-08-14
+
+## Contexto
+
+O ARCA é projetado para atender múltiplas clínicas de psicologia (multi-tenant). Durante o rebuild do frontend, surgiu a questão: vale a pena construir multi-tenancy completo agora, sem nenhum cliente pagante ainda, ou isso é complexidade prematura?
+
+Duas coisas distintas estavam sendo tratadas como uma só:
+
+1. **Isolamento de dados no schema** — cada registro pertencer a uma clínica, e toda query respeitar essa fronteira.
+2. **Features de produto multi-tenant** — onboarding self-serve de clínica, painel de gestão de tenant, billing por tenant, configuração por clínica.
+
+A primeira é barata para implementar agora (banco ainda vazio, sem dado de paciente real). A segunda é trabalho real, e melhor guiado por necessidades de clientes reais do que por suposição.
+
+Retrofitar (1) depois que já existe dado de paciente em produção é significativamente mais arriscado: exige migração de schema com sistema no ar, revisão de toda query existente para garantir que nenhuma ficou sem o filtro de tenant, e qualquer query esquecida vira uma falha de BOLA — nesse caso, uma clínica potencialmente acessando prontuário de paciente de outra clínica, o que é também um incidente de LGPD.
+
+## Decisão
+
+Implementar isolamento de dados no schema agora:
+
+- Novo modelo `Clinica`.
+- Campo `id_Clinica` em `Usuario`, `ListaEspera`, `Atendimento`, `Prontuario` e `LogAuditoria`.
+- Tabelas de apoio (`Role`, `Genero`, `Etnia`, `Escolaridade`, `StatusX`/`TipoX`) permanecem globais, não escopadas por clínica.
+- Enforcement estrutural via Prisma Client Extension que injeta o filtro de `id_Clinica` automaticamente a partir do contexto da requisição, evitando depender de lembrar de filtrar manualmente em cada service.
+- `clinicaId` como claim no JWT, definido no login.
+
+Features de produto multi-tenant (onboarding, painel de gestão, billing, configuração por clínica) ficam explicitamente fora de escopo até haver 2+ clientes reais.
+
+## Consequências
+
+**Positivas:**
+- Nenhuma migração de retrofit dolorosa quando o primeiro cliente real chegar.
+- O gap de segurança nº 1 do projeto (BOLA multi-tenant) é endereçado pela raiz, não por vigilância manual em cada endpoint.
+- Trabalho adicional imediato é pequeno (uma tabela nova, uma coluna em cinco modelos, uma extension).
+
+**Negativas / trade-offs:**
+- Todo endpoint que já existe precisa ser revisado para passar a respeitar o escopo de clínica — trabalho pontual, mas não zero.
+- Sem uma segunda clínica real ainda, há risco de over-engineering se a modelagem de `Clinica` for além do necessário — por isso o escopo aqui é deliberadamente mínimo (id, nome, slug, isActive).
+
+## Alternativas consideradas
+
+- **Multi-tenancy completo agora** (painel de gestão, onboarding self-serve incluídos): rejeitado por complexidade prematura sem clientes reais para validar os requisitos.
+- **Adiar tudo, single-tenant por enquanto**: rejeitado pelo risco de retrofit em produção com dado sensível de paciente já existente.


### PR DESCRIPTION
## Resumo

- Adiciona `AGENTS.md` (resumo imperativo de regras de repositório para agentes de IA)
- Adiciona `docs/ARQUITETURA.md` (visão geral do sistema, status por módulo)
- Adiciona `docs/CONVENTIONS.md` (convenções de componentes frontend e fluxo de versionamento/git)
- Adiciona `docs/adr/0001-multi-tenancy-estrategia-hibrida.md` (primeira ADR — decisão de isolamento de dados no schema)
- Atualiza `CLAUDE.md` e `README.md` para refletir o posicionamento como SaaS multi-tenant e o estado atual do rebuild do frontend

Closes #104

## Test plan

- [x] Mudança é documentação apenas — nenhum código de aplicação alterado
- [x] `npm run lint` rodado; erros pré-existentes encontrados em `session.service.ts`, `users.service.ts`, `waitlist.service.ts` e no frontend são anteriores a esta branch, não introduzidos por ela