### PR TITLE
fix: normalize line endings and fix ESLint/Jest breakage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/apps/backend/eslint.config.mjs
+++ b/apps/backend/eslint.config.mjs
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
     {
-        ignores: ['eslint.config.mjs', 'dist/**', 'node_modules/**'],
+        ignores: ['eslint.config.mjs', 'dist/**', 'node_modules/**', 'coverage/**', 'jest.config.js'],
     },
     eslint.configs.recommended,
     ...tseslint.configs.recommendedTypeChecked,

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -37,7 +37,12 @@ async function main() {
     const existingGeneros = await prisma.genero.count();
     if (existingGeneros === 0) {
         await prisma.genero.createMany({
-            data: [{ nome: 'Masculino' }, { nome: 'Feminino' }, { nome: 'Não-binário' }, { nome: 'Prefiro não informar' }],
+            data: [
+                { nome: 'Masculino' },
+                { nome: 'Feminino' },
+                { nome: 'Não-binário' },
+                { nome: 'Prefiro não informar' },
+            ],
         });
         console.log('✅ Gêneros inseridos com sucesso!');
     } else {

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -34,4 +34,4 @@ import { APP_GUARD } from '@nestjs/core';
     controllers: [AppController],
     providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
 })
-export class AppModule { }
+export class AppModule {}

--- a/apps/backend/src/audit/audit.controller.ts
+++ b/apps/backend/src/audit/audit.controller.ts
@@ -12,7 +12,7 @@ import { AuditFilterDto } from './dto/audit-filter.dto';
 @Controller('audit')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class AuditController {
-    constructor(private auditService: AuditService) { }
+    constructor(private auditService: AuditService) {}
 
     @ApiOperation({ summary: 'Listar logs de auditoria (somente Coordenador)' })
     @ApiResponse({ status: 200, description: 'Lista paginada de logs retornada com sucesso.' })

--- a/apps/backend/src/audit/audit.interceptor.spec.ts
+++ b/apps/backend/src/audit/audit.interceptor.spec.ts
@@ -19,7 +19,7 @@ describe('AuditInterceptor', () => {
     }
 
     beforeEach(() => {
-        jest.spyOn(Logger.prototype, 'error').mockImplementation(() => { });
+        jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
         jest.clearAllMocks();
         mockAuditService.create.mockResolvedValue(undefined);
         interceptor = new AuditInterceptor(mockAuditService as any);

--- a/apps/backend/src/audit/audit.interceptor.ts
+++ b/apps/backend/src/audit/audit.interceptor.ts
@@ -9,7 +9,7 @@ import type { TokenDto } from 'src/common/dto/token.dto';
 export class AuditInterceptor implements NestInterceptor {
     private readonly logger = new Logger(AuditInterceptor.name);
 
-    constructor(private readonly auditService: AuditService) { }
+    constructor(private readonly auditService: AuditService) {}
 
     intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
         const request = context.switchToHttp().getRequest<{
@@ -29,7 +29,10 @@ export class AuditInterceptor implements NestInterceptor {
         return next.handle().pipe(
             tap((data) => {
                 this.logAudit(context, request, data).catch((error: unknown) =>
-                    this.logger.error('Falha ao salvar o log de auditoria', error instanceof Error ? error.stack : error),
+                    this.logger.error(
+                        'Falha ao salvar o log de auditoria',
+                        error instanceof Error ? error.stack : error,
+                    ),
                 );
             }),
         );

--- a/apps/backend/src/audit/audit.module.ts
+++ b/apps/backend/src/audit/audit.module.ts
@@ -10,4 +10,4 @@ import { AuditController } from './audit.controller';
     exports: [AuditService],
     controllers: [AuditController],
 })
-export class AuditModule { }
+export class AuditModule {}

--- a/apps/backend/src/audit/audit.service.ts
+++ b/apps/backend/src/audit/audit.service.ts
@@ -16,7 +16,7 @@ export interface CreateAuditLogDto {
 
 @Injectable()
 export class AuditService {
-    constructor(private readonly prisma: PrismaService) { }
+    constructor(private readonly prisma: PrismaService) {}
 
     async create(logData: CreateAuditLogDto) {
         return await this.prisma.logAuditoria.create({

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -10,7 +10,7 @@ import { LoginDto } from './dto/login.dto';
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
-    constructor(private authService: AuthService) { }
+    constructor(private authService: AuthService) {}
 
     @ApiOperation({ summary: 'Login com e-mail e senha' })
     @ApiBody({ type: LoginDto })

--- a/apps/backend/src/auth/auth.module.ts
+++ b/apps/backend/src/auth/auth.module.ts
@@ -22,4 +22,4 @@ import { PrismaModule } from 'src/prisma/prisma.module';
     exports: [AuthService],
     controllers: [AuthController],
 })
-export class AuthModule { }
+export class AuthModule {}

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -17,7 +17,7 @@ export class AuthService {
         @Inject(jwtConfig.KEY)
         private readonly jwtConfiguration: ConfigType<typeof jwtConfig>,
         private readonly jwtService: JwtService,
-    ) { }
+    ) {}
 
     async validateUser(body: LoginDto): Promise<ValidatedUserDto> {
         const user = await this.prisma.usuario.findFirst({

--- a/apps/backend/src/auth/guards/jwt-auth.guard.ts
+++ b/apps/backend/src/auth/guards/jwt-auth.guard.ts
@@ -2,4 +2,4 @@ import { Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') { }
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/apps/backend/src/auth/guards/local-auth.guard.ts
+++ b/apps/backend/src/auth/guards/local-auth.guard.ts
@@ -2,4 +2,4 @@ import { Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
-export class LocalAuthGuard extends AuthGuard('local') { }
+export class LocalAuthGuard extends AuthGuard('local') {}

--- a/apps/backend/src/auth/hash/hashing.module.ts
+++ b/apps/backend/src/auth/hash/hashing.module.ts
@@ -11,4 +11,4 @@ import { BcryptService } from './bcrypt.service';
     ],
     exports: [HashingServiceProtocol],
 })
-export class HashingModule { }
+export class HashingModule {}

--- a/apps/backend/src/auth/jwt.strategy.ts
+++ b/apps/backend/src/auth/jwt.strategy.ts
@@ -34,6 +34,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
         return {
             ...payload,
-        } as TokenDto;
+        };
     }
 }

--- a/apps/backend/src/common/filters/http-exception.filter.ts
+++ b/apps/backend/src/common/filters/http-exception.filter.ts
@@ -25,11 +25,11 @@ export class HttpExceptionFilter implements ExceptionFilter {
             typeof message === 'string'
                 ? { statusCode: status, timestamp: new Date().toISOString(), path: request.url, message }
                 : {
-                    statusCode: status,
-                    timestamp: new Date().toISOString(),
-                    path: request.url,
-                    ...(message as Record<string, unknown>),
-                };
+                      statusCode: status,
+                      timestamp: new Date().toISOString(),
+                      path: request.url,
+                      ...(message as Record<string, unknown>),
+                  };
 
         response.status(status).json(body);
     }

--- a/apps/backend/src/common/guards/roles.guard.ts
+++ b/apps/backend/src/common/guards/roles.guard.ts
@@ -6,7 +6,7 @@ import type { TokenDto } from '../dto/token.dto';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
-    constructor(private reflector: Reflector) { }
+    constructor(private reflector: Reflector) {}
 
     canActivate(context: ExecutionContext): boolean {
         const requiredRoles = this.reflector.getAllAndOverride<RoleAccess[]>(ROLES_KEY, [

--- a/apps/backend/src/crypto/crypto.module.ts
+++ b/apps/backend/src/crypto/crypto.module.ts
@@ -7,4 +7,4 @@ import { ConfigModule } from '@nestjs/config';
     providers: [CryptoService],
     exports: [CryptoService],
 })
-export class CryptoModule { }
+export class CryptoModule {}

--- a/apps/backend/src/crypto/crypto.service.spec.ts
+++ b/apps/backend/src/crypto/crypto.service.spec.ts
@@ -44,7 +44,9 @@ describe('CryptoService', () => {
     });
 
     it('deve lançar erro se o formato for inválido (sem ":")', () => {
-        expect(() => service.decrypt('dado-invalido-sem-separadores')).toThrow('Formato de dado criptografado inválido.');
+        expect(() => service.decrypt('dado-invalido-sem-separadores')).toThrow(
+            'Formato de dado criptografado inválido.',
+        );
     });
 
     it('deve lançar erro ao construir com chave de tamanho errado', async () => {

--- a/apps/backend/src/medical_record/dto/conteudo-evolucao.dto.ts
+++ b/apps/backend/src/medical_record/dto/conteudo-evolucao.dto.ts
@@ -2,7 +2,10 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsNotEmpty, IsBoolean } from 'class-validator';
 
 export class ConteudoEvolucaoDto {
-    @ApiProperty({ example: 'Paciente apresentou melhora nos sintomas de ansiedade. Técnica de respiração aplicada.', description: 'Relatório narrativo da sessão de psicoterapia' })
+    @ApiProperty({
+        example: 'Paciente apresentou melhora nos sintomas de ansiedade. Técnica de respiração aplicada.',
+        description: 'Relatório narrativo da sessão de psicoterapia',
+    })
     @IsNotEmpty({ message: 'O relatorio não pode estar vazio.' })
     @IsString()
     relatorioDaSessao: string;

--- a/apps/backend/src/medical_record/dto/conteudo-relatorio-alta.dto.ts
+++ b/apps/backend/src/medical_record/dto/conteudo-relatorio-alta.dto.ts
@@ -10,27 +10,43 @@ export enum MotivoAltaEnum {
 }
 
 export class ConteudoRelatorioAltaDto {
-    @ApiProperty({ enum: MotivoAltaEnum, example: MotivoAltaEnum.OBJETIVOS_ATINGIDOS, description: 'Motivo da alta terapêutica' })
+    @ApiProperty({
+        enum: MotivoAltaEnum,
+        example: MotivoAltaEnum.OBJETIVOS_ATINGIDOS,
+        description: 'Motivo da alta terapêutica',
+    })
     @IsNotEmpty({ message: 'O motivo da alta é obrigatório.' })
     @IsEnum(MotivoAltaEnum)
     motivoAlta: MotivoAltaEnum;
 
-    @ApiProperty({ example: 'O processo terapêutico durou 8 meses com foco em TCC para ansiedade.', description: 'Resumo do processo terapêutico realizado' })
+    @ApiProperty({
+        example: 'O processo terapêutico durou 8 meses com foco em TCC para ansiedade.',
+        description: 'Resumo do processo terapêutico realizado',
+    })
     @IsNotEmpty({ message: 'O resumo do processo terapêutico não pode estar vazio.' })
     @IsString()
     resumoProcessoTerapeutico: string;
 
-    @ApiProperty({ example: 'Redução significativa dos episódios de ansiedade e melhora na qualidade do sono.', description: 'Resultados alcançados ao longo do processo' })
+    @ApiProperty({
+        example: 'Redução significativa dos episódios de ansiedade e melhora na qualidade do sono.',
+        description: 'Resultados alcançados ao longo do processo',
+    })
     @IsNotEmpty({ message: 'É necessário descrever os resultados alcançados.' })
     @IsString()
     resultadosAlcancados: string;
 
-    @ApiPropertyOptional({ example: 'F41.1 - Transtorno de ansiedade generalizada', description: 'Diagnóstico final (CID-10 ou DSM-5)' })
+    @ApiPropertyOptional({
+        example: 'F41.1 - Transtorno de ansiedade generalizada',
+        description: 'Diagnóstico final (CID-10 ou DSM-5)',
+    })
     @IsOptional()
     @IsString()
     diagnosticoFinal?: string;
 
-    @ApiPropertyOptional({ example: 'Manter práticas de mindfulness e retornar se necessário.', description: 'Recomendações para o período pós-alta' })
+    @ApiPropertyOptional({
+        example: 'Manter práticas de mindfulness e retornar se necessário.',
+        description: 'Recomendações para o período pós-alta',
+    })
     @IsOptional()
     @IsString()
     recomendacoesPosAlta?: string;

--- a/apps/backend/src/medical_record/dto/conteudo-triagem.dto.ts
+++ b/apps/backend/src/medical_record/dto/conteudo-triagem.dto.ts
@@ -2,7 +2,10 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsNotEmpty, IsBoolean } from 'class-validator';
 
 export class ConteudoTriagemDto {
-    @ApiProperty({ example: 'Paciente relata ansiedade intensa há 6 meses após perda de emprego.', description: 'Relatório narrativo da sessão de triagem' })
+    @ApiProperty({
+        example: 'Paciente relata ansiedade intensa há 6 meses após perda de emprego.',
+        description: 'Relatório narrativo da sessão de triagem',
+    })
     @IsNotEmpty({ message: 'O relatorio não pode estar vazio.' })
     @IsString()
     relatorioDaSessao: string;

--- a/apps/backend/src/medical_record/dto/create-alta.dtos.ts
+++ b/apps/backend/src/medical_record/dto/create-alta.dtos.ts
@@ -8,7 +8,10 @@ export class CreateAltaDto extends CreateEncaminhamentoDto {
     @IsBoolean()
     recebeuAlta: boolean;
 
-    @ApiPropertyOptional({ example: 'Alta terapêutica por objetivos atingidos.', description: 'Finalidade ou descrição da alta' })
+    @ApiPropertyOptional({
+        example: 'Alta terapêutica por objetivos atingidos.',
+        description: 'Finalidade ou descrição da alta',
+    })
     @IsOptional()
     @IsString({
         message: 'O campo instituicaoEncaminhada deve ser um texto.',

--- a/apps/backend/src/medical_record/dto/create-encaminhamento.dto.ts
+++ b/apps/backend/src/medical_record/dto/create-encaminhamento.dto.ts
@@ -7,14 +7,20 @@ export class CreateEncaminhamentoDto {
     @IsBoolean()
     encaminhado: boolean;
 
-    @ApiPropertyOptional({ example: 'CAPS - Centro de Atenção Psicossocial', description: 'Instituição para a qual o paciente foi encaminhado (obrigatório se encaminhado=true)' })
+    @ApiPropertyOptional({
+        example: 'CAPS - Centro de Atenção Psicossocial',
+        description: 'Instituição para a qual o paciente foi encaminhado (obrigatório se encaminhado=true)',
+    })
     @IsOptional()
     @IsString({
         message: 'O campo instituicaoEncaminhada deve ser um texto.',
     })
     instituicaoEncaminhada?: string;
 
-    @ApiPropertyOptional({ example: 'Necessidade de acompanhamento psiquiátrico.', description: 'Motivo do encaminhamento externo' })
+    @ApiPropertyOptional({
+        example: 'Necessidade de acompanhamento psiquiátrico.',
+        description: 'Motivo do encaminhamento externo',
+    })
     @IsOptional()
     @IsString({
         message: 'O campo motivoEncaminhamento deve ser um texto.',

--- a/apps/backend/src/medical_record/dto/create-evolucao-medical_record.dto.ts
+++ b/apps/backend/src/medical_record/dto/create-evolucao-medical_record.dto.ts
@@ -5,7 +5,10 @@ import { ConteudoEvolucaoDto } from './conteudo-evolucao.dto';
 import { UUID } from 'node:crypto';
 
 export class CreateEvolucaoProntuarioDto {
-    @ApiProperty({ example: 'uuid-do-atendimento', description: 'UUID do atendimento de psicoterapia ao qual o prontuário pertence' })
+    @ApiProperty({
+        example: 'uuid-do-atendimento',
+        description: 'UUID do atendimento de psicoterapia ao qual o prontuário pertence',
+    })
     @IsNotEmpty({ message: 'O ID da sessão é obrigatório.' })
     @IsUUID()
     id_Sessao: UUID;

--- a/apps/backend/src/medical_record/dto/create-triagem-medical_record.dto.ts
+++ b/apps/backend/src/medical_record/dto/create-triagem-medical_record.dto.ts
@@ -5,7 +5,10 @@ import { ConteudoTriagemDto } from './conteudo-triagem.dto';
 import { UUID } from 'node:crypto';
 
 export class CreateTriagemProntuarioDto {
-    @ApiProperty({ example: 'uuid-do-atendimento', description: 'UUID do atendimento de triagem ao qual o prontuário pertence' })
+    @ApiProperty({
+        example: 'uuid-do-atendimento',
+        description: 'UUID do atendimento de triagem ao qual o prontuário pertence',
+    })
     @IsNotEmpty({ message: 'O ID da sessão é obrigatório.' })
     @IsUUID()
     id_Sessao: UUID;

--- a/apps/backend/src/medical_record/medical_record.controller.ts
+++ b/apps/backend/src/medical_record/medical_record.controller.ts
@@ -22,11 +22,14 @@ import { Response } from 'express';
 @Controller('medical-record')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class MedicalRecordController {
-    constructor(private readonly medicalRecordService: MedicalRecordService) { }
+    constructor(private readonly medicalRecordService: MedicalRecordService) {}
 
     @ApiOperation({ summary: 'Criar prontuário de triagem (Coordenador/Supervisor/Estagiário)' })
     @ApiResponse({ status: 201, description: 'Prontuário de triagem criado.' })
-    @ApiResponse({ status: 400, description: 'Atendimento não é do tipo triagem, já concluído ou paciente sem status correto.' })
+    @ApiResponse({
+        status: 400,
+        description: 'Atendimento não é do tipo triagem, já concluído ou paciente sem status correto.',
+    })
     @ApiResponse({ status: 401, description: 'Não autenticado.' })
     @ApiResponse({ status: 403, description: 'Usuário não é o responsável pelo atendimento.' })
     @ApiResponse({ status: 404, description: 'Atendimento não encontrado.' })
@@ -53,7 +56,10 @@ export class MedicalRecordController {
     }
 
     @ApiOperation({ summary: 'Aprovar prontuário de triagem e decidir encaminhamento (Coordenador/Supervisor)' })
-    @ApiResponse({ status: 200, description: 'Triagem aprovada. Paciente encaminhado para psicoterapia ou serviço externo.' })
+    @ApiResponse({
+        status: 200,
+        description: 'Triagem aprovada. Paciente encaminhado para psicoterapia ou serviço externo.',
+    })
     @ApiResponse({ status: 400, description: 'Prontuário já aprovado, ou encaminhado=true sem instituição informada.' })
     @ApiResponse({ status: 401, description: 'Não autenticado.' })
     @ApiResponse({ status: 403, description: 'Somente o supervisor responsável pode aprovar.' })
@@ -70,7 +76,10 @@ export class MedicalRecordController {
 
     @ApiOperation({ summary: 'Criar prontuário de evolução de psicoterapia (Coordenador/Supervisor/Estagiário)' })
     @ApiResponse({ status: 201, description: 'Prontuário de evolução criado.' })
-    @ApiResponse({ status: 400, description: 'Atendimento não é do tipo psicoterapia, já concluído ou paciente sem status correto.' })
+    @ApiResponse({
+        status: 400,
+        description: 'Atendimento não é do tipo psicoterapia, já concluído ou paciente sem status correto.',
+    })
     @ApiResponse({ status: 401, description: 'Não autenticado.' })
     @ApiResponse({ status: 403, description: 'Usuário não é o responsável pelo atendimento.' })
     @ApiResponse({ status: 404, description: 'Atendimento não encontrado.' })
@@ -137,7 +146,11 @@ export class MedicalRecordController {
     @ApiResponse({ status: 401, description: 'Não autenticado.' })
     @ApiResponse({ status: 404, description: 'Prontuário de encaminhamento não encontrado.' })
     @Get('prontuarios/encaminhamento/pdf/:id')
-    generateEncaminhamentoPdf(@Param('id', ParseUUIDPipe) id: UUID, @CurrentUser() user: TokenDto, @Res() res: Response) {
+    generateEncaminhamentoPdf(
+        @Param('id', ParseUUIDPipe) id: UUID,
+        @CurrentUser() user: TokenDto,
+        @Res() res: Response,
+    ) {
         return this.medicalRecordService.generateEncaminhamentoPdf(id, user, res);
     }
 

--- a/apps/backend/src/medical_record/medical_record.module.ts
+++ b/apps/backend/src/medical_record/medical_record.module.ts
@@ -10,4 +10,4 @@ import { CryptoModule } from 'src/crypto/crypto.module';
     controllers: [MedicalRecordController],
     providers: [MedicalRecordService],
 })
-export class MedicalRecordModule { }
+export class MedicalRecordModule {}

--- a/apps/backend/src/medical_record/medical_record.service.spec.ts
+++ b/apps/backend/src/medical_record/medical_record.service.spec.ts
@@ -86,11 +86,11 @@ describe('MedicalRecordService', () => {
     let service: MedicalRecordService;
 
     beforeEach(() => {
-        jest.spyOn(Logger.prototype, 'error').mockImplementation(() => { });
+        jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
         jest.clearAllMocks();
         mockCryptoService.encrypt.mockReturnValue('encrypted-content');
         mockCryptoService.decryptConteudo.mockImplementation((c: unknown) => c);
-        service = new MedicalRecordService(mockPrisma as any, mockPdfService as any, mockCryptoService as any);
+        service = new MedicalRecordService(mockPrisma as any, mockPdfService, mockCryptoService as any);
     });
 
     it('should be defined', () => {
@@ -105,7 +105,9 @@ describe('MedicalRecordService', () => {
                 it('should throw NotFoundException when atendimento does not exist', async () => {
                     mockPrisma.atendimento.findFirst.mockResolvedValue(null);
 
-                    await expect(service.createTriagem(dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(NotFoundException);
+                    await expect(service.createTriagem(dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(
+                        NotFoundException,
+                    );
                 });
 
                 it('should throw BadRequestException when atendimento is not triagem type', async () => {
@@ -113,7 +115,9 @@ describe('MedicalRecordService', () => {
                         makeAtendimento({ id_Tipo_Atendimento: TipoAtendimento.PSICOTERAPIA }),
                     );
 
-                    await expect(service.createTriagem(dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(BadRequestException);
+                    await expect(service.createTriagem(dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(
+                        BadRequestException,
+                    );
                 });
 
                 it('should throw BadRequestException when atendimento is not active', async () => {
@@ -121,7 +125,9 @@ describe('MedicalRecordService', () => {
                         makeAtendimento({ id_Status: StatusAtendimento.CONCLUIDO }),
                     );
 
-                    await expect(service.createTriagem(dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(BadRequestException);
+                    await expect(service.createTriagem(dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(
+                        BadRequestException,
+                    );
                 });
 
                 it('should throw BadRequestException when patient is not in triagem status', async () => {
@@ -129,7 +135,9 @@ describe('MedicalRecordService', () => {
                         makeAtendimento({ ListaEspera: { id_Status: StatusListaEspera.EM_ESPERA } }),
                     );
 
-                    await expect(service.createTriagem(dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(BadRequestException);
+                    await expect(service.createTriagem(dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(
+                        BadRequestException,
+                    );
                 });
 
                 it('should throw InternalServerErrorException when atendimento has no estagiario or supervisor', async () => {
@@ -184,7 +192,9 @@ describe('MedicalRecordService', () => {
                 it('should throw NotFoundException when atendimento does not exist', async () => {
                     mockPrisma.atendimento.findFirst.mockResolvedValue(null);
 
-                    await expect(service.createEvolucao(dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(NotFoundException);
+                    await expect(service.createEvolucao(dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(
+                        NotFoundException,
+                    );
                 });
 
                 it('should throw BadRequestException when atendimento is not psicoterapia type', async () => {
@@ -195,7 +205,9 @@ describe('MedicalRecordService', () => {
                         }),
                     );
 
-                    await expect(service.createEvolucao(dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(BadRequestException);
+                    await expect(service.createEvolucao(dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(
+                        BadRequestException,
+                    );
                 });
 
                 it('should throw BadRequestException when patient does not have approved triagem', async () => {
@@ -206,7 +218,9 @@ describe('MedicalRecordService', () => {
                         }),
                     );
 
-                    await expect(service.createEvolucao(dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(BadRequestException);
+                    await expect(service.createEvolucao(dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(
+                        BadRequestException,
+                    );
                 });
 
                 it('should create evolucao and return the prontuario', async () => {
@@ -321,19 +335,29 @@ describe('MedicalRecordService', () => {
                 it('should throw NotFoundException when prontuario does not exist', async () => {
                     mockPrisma.prontuario.findUnique.mockResolvedValue(null);
 
-                    await expect(service.putTriagem(id, dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(NotFoundException);
+                    await expect(service.putTriagem(id, dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(
+                        NotFoundException,
+                    );
                 });
 
                 it('should throw BadRequestException when prontuario is not triagem type', async () => {
-                    mockPrisma.prontuario.findUnique.mockResolvedValue(makeProntuario({ id_Tipo: TipoProntuario.PSICOTERAPIA }));
+                    mockPrisma.prontuario.findUnique.mockResolvedValue(
+                        makeProntuario({ id_Tipo: TipoProntuario.PSICOTERAPIA }),
+                    );
 
-                    await expect(service.putTriagem(id, dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(BadRequestException);
+                    await expect(service.putTriagem(id, dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(
+                        BadRequestException,
+                    );
                 });
 
                 it('should throw BadRequestException when triagem is already approved', async () => {
-                    mockPrisma.prontuario.findUnique.mockResolvedValue(makeProntuario({ id_Status: StatusProntuario.APROVADO }));
+                    mockPrisma.prontuario.findUnique.mockResolvedValue(
+                        makeProntuario({ id_Status: StatusProntuario.APROVADO }),
+                    );
 
-                    await expect(service.putTriagem(id, dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(BadRequestException);
+                    await expect(service.putTriagem(id, dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(
+                        BadRequestException,
+                    );
                 });
 
                 it('should throw ForbiddenException when supervisor is not responsible', async () => {
@@ -369,13 +393,19 @@ describe('MedicalRecordService', () => {
                 it('should throw NotFoundException when prontuario does not exist', async () => {
                     mockPrisma.prontuario.findUnique.mockResolvedValue(null);
 
-                    await expect(service.putEvolucao(id, dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(NotFoundException);
+                    await expect(service.putEvolucao(id, dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(
+                        NotFoundException,
+                    );
                 });
 
                 it('should throw BadRequestException when prontuario is not psicoterapia type', async () => {
-                    mockPrisma.prontuario.findUnique.mockResolvedValue(makeProntuario({ id_Tipo: TipoProntuario.TRIAGEM }));
+                    mockPrisma.prontuario.findUnique.mockResolvedValue(
+                        makeProntuario({ id_Tipo: TipoProntuario.TRIAGEM }),
+                    );
 
-                    await expect(service.putEvolucao(id, dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(BadRequestException);
+                    await expect(service.putEvolucao(id, dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(
+                        BadRequestException,
+                    );
                 });
 
                 it('should throw BadRequestException when evolucao is already approved', async () => {
@@ -383,12 +413,16 @@ describe('MedicalRecordService', () => {
                         makeProntuario({ id_Tipo: TipoProntuario.PSICOTERAPIA, id_Status: StatusProntuario.APROVADO }),
                     );
 
-                    await expect(service.putEvolucao(id, dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(BadRequestException);
+                    await expect(service.putEvolucao(id, dto, makeUser(RoleAccess.ADMIN))).rejects.toThrow(
+                        BadRequestException,
+                    );
                 });
 
                 it('should update and return the evolucao', async () => {
                     const updated = makeProntuario({ id_Tipo: TipoProntuario.PSICOTERAPIA });
-                    mockPrisma.prontuario.findUnique.mockResolvedValue(makeProntuario({ id_Tipo: TipoProntuario.PSICOTERAPIA }));
+                    mockPrisma.prontuario.findUnique.mockResolvedValue(
+                        makeProntuario({ id_Tipo: TipoProntuario.PSICOTERAPIA }),
+                    );
                     mockPrisma.prontuario.update.mockResolvedValue(updated);
 
                     const result = await service.putEvolucao(id, dto, makeUser(RoleAccess.ADMIN));
@@ -474,7 +508,9 @@ describe('MedicalRecordService', () => {
             });
 
             it('should throw ForbiddenException when supervisor is not responsible', async () => {
-                mockPrisma.prontuario.findUnique.mockResolvedValue(makeProntuario({ id_Tipo: TipoProntuario.PSICOTERAPIA }));
+                mockPrisma.prontuario.findUnique.mockResolvedValue(
+                    makeProntuario({ id_Tipo: TipoProntuario.PSICOTERAPIA }),
+                );
 
                 await expect(
                     service.approveEvolucao(
@@ -486,7 +522,9 @@ describe('MedicalRecordService', () => {
             });
 
             it('should approve evolucao without alta or encaminhamento', async () => {
-                mockPrisma.prontuario.findUnique.mockResolvedValue(makeProntuario({ id_Tipo: TipoProntuario.PSICOTERAPIA }));
+                mockPrisma.prontuario.findUnique.mockResolvedValue(
+                    makeProntuario({ id_Tipo: TipoProntuario.PSICOTERAPIA }),
+                );
                 mockPrisma.$transaction.mockResolvedValue([]);
 
                 const result = await service.approveEvolucao(
@@ -499,7 +537,9 @@ describe('MedicalRecordService', () => {
             });
 
             it('should approve evolucao with alta', async () => {
-                mockPrisma.prontuario.findUnique.mockResolvedValue(makeProntuario({ id_Tipo: TipoProntuario.PSICOTERAPIA }));
+                mockPrisma.prontuario.findUnique.mockResolvedValue(
+                    makeProntuario({ id_Tipo: TipoProntuario.PSICOTERAPIA }),
+                );
                 mockPrisma.$transaction.mockResolvedValue([]);
 
                 const result = await service.approveEvolucao(
@@ -512,7 +552,9 @@ describe('MedicalRecordService', () => {
             });
 
             it('should approve evolucao with encaminhamento', async () => {
-                mockPrisma.prontuario.findUnique.mockResolvedValue(makeProntuario({ id_Tipo: TipoProntuario.PSICOTERAPIA }));
+                mockPrisma.prontuario.findUnique.mockResolvedValue(
+                    makeProntuario({ id_Tipo: TipoProntuario.PSICOTERAPIA }),
+                );
                 mockPrisma.$transaction.mockResolvedValue([]);
 
                 const result = await service.approveEvolucao(
@@ -530,7 +572,9 @@ describe('MedicalRecordService', () => {
             });
 
             it('should approve evolucao with both alta and encaminhamento', async () => {
-                mockPrisma.prontuario.findUnique.mockResolvedValue(makeProntuario({ id_Tipo: TipoProntuario.PSICOTERAPIA }));
+                mockPrisma.prontuario.findUnique.mockResolvedValue(
+                    makeProntuario({ id_Tipo: TipoProntuario.PSICOTERAPIA }),
+                );
                 mockPrisma.$transaction.mockResolvedValue([]);
 
                 const result = await service.approveEvolucao(

--- a/apps/backend/src/medical_record/medical_record.service.ts
+++ b/apps/backend/src/medical_record/medical_record.service.ts
@@ -43,7 +43,7 @@ export class MedicalRecordService {
         private prisma: PrismaService,
         private pdfService: PdfService,
         private cryptoService: CryptoService,
-    ) { }
+    ) {}
 
     private encrypt(data: object): string {
         return this.cryptoService.encrypt(data);
@@ -63,11 +63,11 @@ export class MedicalRecordService {
             },
         });
         if (!atendimento) throw new NotFoundException('Atendimento não encontrado.');
-        if ((atendimento?.id_Tipo_Atendimento as TipoAtendimento) !== TipoAtendimento.TRIAGEM)
+        if (atendimento?.id_Tipo_Atendimento !== TipoAtendimento.TRIAGEM)
             throw new BadRequestException('Atendimento não é de triagem.');
-        if ((atendimento.id_Status as StatusAtendimento) !== StatusAtendimento.ATIVO)
+        if (atendimento.id_Status !== StatusAtendimento.ATIVO)
             throw new BadRequestException('Atendimento não está ativo ou já foi concluido.');
-        if ((atendimento.ListaEspera?.id_Status as StatusListaEspera) !== StatusListaEspera.EM_TRIAGEM)
+        if (atendimento.ListaEspera?.id_Status !== StatusListaEspera.EM_TRIAGEM)
             throw new BadRequestException(
                 'Paciente ja possuí triagem concluída ou em andamento. Não é possível criar outra triagem.',
             );
@@ -108,7 +108,9 @@ export class MedicalRecordService {
             return relatorioTriagem;
         } catch (error) {
             this.logger.error('Falha ao salvar triagem', error instanceof Error ? error.stack : error);
-            throw new InternalServerErrorException('Erro no banco de dados. Falha ao salvar a triagem. Tente novamente.');
+            throw new InternalServerErrorException(
+                'Erro no banco de dados. Falha ao salvar a triagem. Tente novamente.',
+            );
         }
     }
 
@@ -127,9 +129,8 @@ export class MedicalRecordService {
         });
 
         if (!prontuario) throw new NotFoundException('Registro não encontrado.');
-        if ((prontuario.id_Tipo as TipoProntuario) !== TipoProntuario.TRIAGEM)
-            throw new BadRequestException('Registro não é de triagem.');
-        if ((prontuario.id_Status as StatusProntuario) !== StatusProntuario.EM_APROVACAO)
+        if (prontuario.id_Tipo !== TipoProntuario.TRIAGEM) throw new BadRequestException('Registro não é de triagem.');
+        if (prontuario.id_Status !== StatusProntuario.EM_APROVACAO)
             throw new BadRequestException('Triagem já foi aprovada, não é possível alterar os dados.');
 
         if (!prontuario.atendimento?.id_Supervisor_Executor)
@@ -164,9 +165,8 @@ export class MedicalRecordService {
         });
 
         if (!prontuario) throw new NotFoundException('Registro não encontrado.');
-        if ((prontuario.id_Tipo as TipoProntuario) !== TipoProntuario.TRIAGEM)
-            throw new BadRequestException('Registro não é de triagem.');
-        if ((prontuario.id_Status as StatusProntuario) !== StatusProntuario.EM_APROVACAO)
+        if (prontuario.id_Tipo !== TipoProntuario.TRIAGEM) throw new BadRequestException('Registro não é de triagem.');
+        if (prontuario.id_Status !== StatusProntuario.EM_APROVACAO)
             throw new BadRequestException('Triagem já foi aprovada.');
         if (!prontuario.atendimento?.id_Supervisor_Executor)
             throw new InternalServerErrorException('Dados do atendimento inválidos.');
@@ -201,7 +201,9 @@ export class MedicalRecordService {
                 );
             }
             if (!motivoEncaminhamento || motivoEncaminhamento.trim() === '') {
-                throw new BadRequestException('O campo motivoEncaminhamento é obrigatório quando "encaminhado" é verdadeiro.');
+                throw new BadRequestException(
+                    'O campo motivoEncaminhamento é obrigatório quando "encaminhado" é verdadeiro.',
+                );
             }
 
             transactionPromises.push(
@@ -242,7 +244,9 @@ export class MedicalRecordService {
                 : 'Triagem aprovada com sucesso.';
         } catch (error) {
             this.logger.error('Falha ao aprovar triagem', error instanceof Error ? error.stack : error);
-            throw new InternalServerErrorException('Erro no banco de dados. Falha ao aprovar a triagem. Tente novamente.');
+            throw new InternalServerErrorException(
+                'Erro no banco de dados. Falha ao aprovar a triagem. Tente novamente.',
+            );
         }
     }
 
@@ -254,12 +258,12 @@ export class MedicalRecordService {
             },
         });
         if (!atendimento) throw new NotFoundException('Atendimento não encontrado.');
-        if ((atendimento?.id_Tipo_Atendimento as TipoAtendimento) !== TipoAtendimento.PSICOTERAPIA)
+        if (atendimento?.id_Tipo_Atendimento !== TipoAtendimento.PSICOTERAPIA)
             throw new BadRequestException('Atendimento não é de psicoterapia');
-        if ((atendimento.id_Status as StatusAtendimento) !== StatusAtendimento.ATIVO)
+        if (atendimento.id_Status !== StatusAtendimento.ATIVO)
             throw new BadRequestException('Atendimento não está ativo ou já foi concluido.');
 
-        const status = atendimento.ListaEspera?.id_Status as StatusListaEspera;
+        const status = atendimento.ListaEspera?.id_Status;
         if (status !== StatusListaEspera.TRIAGEM_APROVADA && status !== StatusListaEspera.EM_PSICOTERAPIA)
             throw new BadRequestException(
                 'Paciente não possuí triagem aprovada. Não é possível criar um registro de psicoterapia.',
@@ -300,7 +304,10 @@ export class MedicalRecordService {
 
             return relatorioEvolucao;
         } catch (error) {
-            this.logger.error('Falha ao salvar relatório de psicoterapia', error instanceof Error ? error.stack : error);
+            this.logger.error(
+                'Falha ao salvar relatório de psicoterapia',
+                error instanceof Error ? error.stack : error,
+            );
             throw new InternalServerErrorException(
                 'Erro no banco de dados. Falha ao salvar o relatorio de psicoterapia. Tente novamente.',
             );
@@ -322,9 +329,9 @@ export class MedicalRecordService {
         });
 
         if (!prontuario) throw new NotFoundException('Registro não encontrado.');
-        if ((prontuario.id_Tipo as TipoProntuario) !== TipoProntuario.PSICOTERAPIA)
+        if (prontuario.id_Tipo !== TipoProntuario.PSICOTERAPIA)
             throw new BadRequestException('Registro não é de evolução/psicoterapia.');
-        if ((prontuario.id_Status as StatusProntuario) !== StatusProntuario.EM_APROVACAO)
+        if (prontuario.id_Status !== StatusProntuario.EM_APROVACAO)
             throw new BadRequestException('Registro de evolução já foi aprovado, não é possível alterar os dados.');
 
         if (!prontuario.atendimento?.id_Supervisor_Executor)
@@ -359,9 +366,9 @@ export class MedicalRecordService {
         });
 
         if (!prontuario) throw new NotFoundException('Registro não encontrado.');
-        if ((prontuario.id_Tipo as TipoProntuario) !== TipoProntuario.PSICOTERAPIA)
+        if (prontuario.id_Tipo !== TipoProntuario.PSICOTERAPIA)
             throw new BadRequestException('Registro não é de registro em psicoterapia.');
-        if ((prontuario.id_Status as StatusProntuario) !== StatusProntuario.EM_APROVACAO)
+        if (prontuario.id_Status !== StatusProntuario.EM_APROVACAO)
             throw new BadRequestException('Registro de psicoterapia já foi aprovado.');
         if (!prontuario.atendimento?.id_Supervisor_Executor)
             throw new InternalServerErrorException('Dados do atendimento inválidos.');
@@ -426,7 +433,9 @@ export class MedicalRecordService {
                 );
             }
             if (!motivoEncaminhamento || motivoEncaminhamento.trim() === '') {
-                throw new BadRequestException('O campo motivoEncaminhamento é obrigatório quando "encaminhado" é verdadeiro.');
+                throw new BadRequestException(
+                    'O campo motivoEncaminhamento é obrigatório quando "encaminhado" é verdadeiro.',
+                );
             }
 
             transactionPromises.push(
@@ -456,7 +465,9 @@ export class MedicalRecordService {
             }
         } catch (error) {
             this.logger.error('Falha ao aprovar evolução', error instanceof Error ? error.stack : error);
-            throw new InternalServerErrorException('Erro no banco de dados. Falha ao aprovar a evolução. Tente novamente.');
+            throw new InternalServerErrorException(
+                'Erro no banco de dados. Falha ao aprovar a evolução. Tente novamente.',
+            );
         }
     }
 
@@ -506,14 +517,14 @@ export class MedicalRecordService {
         const paciente = await this.findOne(id, user);
 
         const atdComAlta = paciente.Atendimento.find((atd) =>
-            atd.Prontuario.some((p) => (p.id_Tipo as TipoProntuario) === TipoProntuario.ALTA),
+            atd.Prontuario.some((p) => p.id_Tipo === TipoProntuario.ALTA),
         );
 
         if (!atdComAlta) {
             throw new NotFoundException('Registro de Alta não encontrado para este paciente.');
         }
 
-        const altaRecord = atdComAlta.Prontuario.find((p) => (p.id_Tipo as TipoProntuario) === TipoProntuario.ALTA)!;
+        const altaRecord = atdComAlta.Prontuario.find((p) => p.id_Tipo === TipoProntuario.ALTA)!;
         const supervisorNome = atdComAlta.supervisorExecutor?.nome ?? 'N/A';
         const supervisorCRP = atdComAlta.supervisorExecutor?.CRP ?? 'N/A';
 
@@ -568,7 +579,7 @@ export class MedicalRecordService {
             throw new NotFoundException('Registro de Encaminhamento não encontrado.');
         }
 
-        if ((encaminhamentoRecord.id_Tipo as TipoProntuario) !== TipoProntuario.ENCAMINHAMENTO) {
+        if (encaminhamentoRecord.id_Tipo !== TipoProntuario.ENCAMINHAMENTO) {
             throw new BadRequestException('O registro fornecido não é do tipo Encaminhamento.');
         }
 

--- a/apps/backend/src/pdf/pdf.module.ts
+++ b/apps/backend/src/pdf/pdf.module.ts
@@ -5,4 +5,4 @@ import { PdfService } from './pdf.service';
     providers: [PdfService],
     exports: [PdfService],
 })
-export class PdfModule { }
+export class PdfModule {}

--- a/apps/backend/src/pdf/pdf.service.ts
+++ b/apps/backend/src/pdf/pdf.service.ts
@@ -30,7 +30,7 @@ export class PdfService {
         const page = await browser.newPage();
 
         await page.setContent(htmlContent, {
-            waitUntil: 'networkidle0',
+            waitUntil: 'load',
         });
 
         const pdfBuffer = await page.pdf({

--- a/apps/backend/src/prisma/prisma.module.ts
+++ b/apps/backend/src/prisma/prisma.module.ts
@@ -5,4 +5,4 @@ import { PrismaService } from './prisma.service';
     providers: [PrismaService],
     exports: [PrismaService],
 })
-export class PrismaModule { }
+export class PrismaModule {}

--- a/apps/backend/src/session/dto/create-session.dto.ts
+++ b/apps/backend/src/session/dto/create-session.dto.ts
@@ -34,7 +34,10 @@ export class CreateSessionDto {
     @IsNotEmpty()
     id_Tipo_Atendimento: number;
 
-    @ApiPropertyOptional({ example: 'Paciente solicitou horário vespertino.', description: 'Observações sobre o agendamento' })
+    @ApiPropertyOptional({
+        example: 'Paciente solicitou horário vespertino.',
+        description: 'Observações sobre o agendamento',
+    })
     @IsString()
     @IsOptional()
     observacoes?: string;

--- a/apps/backend/src/session/dto/update-session.dto.ts
+++ b/apps/backend/src/session/dto/update-session.dto.ts
@@ -8,4 +8,4 @@ export class UpdateSessionDto extends PartialType(
         'id_Supervisor_Executor',
         'id_Tipo_Atendimento',
     ] as const),
-) { }
+) {}

--- a/apps/backend/src/session/entities/session.entity.ts
+++ b/apps/backend/src/session/entities/session.entity.ts
@@ -1,1 +1,1 @@
-export class Session { }
+export class Session {}

--- a/apps/backend/src/session/session.controller.ts
+++ b/apps/backend/src/session/session.controller.ts
@@ -17,11 +17,15 @@ import { PaginationDto } from 'src/common/dto/pagination.dto';
 @Controller('session')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class SessionController {
-    constructor(private readonly sessionService: SessionService) { }
+    constructor(private readonly sessionService: SessionService) {}
 
     @ApiOperation({ summary: 'Agendar novo atendimento (Coordenador/Secretário)' })
     @ApiResponse({ status: 201, description: 'Atendimento agendado com sucesso.' })
-    @ApiResponse({ status: 400, description: 'Dados inválidos: paciente sem status correto, conflito de horário, papéis inválidos ou datas incorretas.' })
+    @ApiResponse({
+        status: 400,
+        description:
+            'Dados inválidos: paciente sem status correto, conflito de horário, papéis inválidos ou datas incorretas.',
+    })
     @ApiResponse({ status: 401, description: 'Não autenticado.' })
     @ApiResponse({ status: 403, description: 'Acesso negado. Somente Coordenadores e Secretários.' })
     @ApiResponse({ status: 404, description: 'Paciente, estagiário ou supervisor não encontrado.' })

--- a/apps/backend/src/session/session.module.ts
+++ b/apps/backend/src/session/session.module.ts
@@ -9,4 +9,4 @@ import { CryptoModule } from 'src/crypto/crypto.module';
     controllers: [SessionController],
     providers: [SessionService],
 })
-export class SessionModule { }
+export class SessionModule {}

--- a/apps/backend/src/session/session.service.spec.ts
+++ b/apps/backend/src/session/session.service.spec.ts
@@ -117,7 +117,9 @@ describe('SessionService', () => {
                     };
 
                     mockPrisma.listaEspera.findUnique.mockResolvedValue(patient);
-                    await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(BadRequestException);
+                    await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(
+                        BadRequestException,
+                    );
                 });
             });
 
@@ -175,7 +177,9 @@ describe('SessionService', () => {
                     };
 
                     mockPrisma.listaEspera.findUnique.mockResolvedValue(patient);
-                    await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(BadRequestException);
+                    await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(
+                        BadRequestException,
+                    );
                 });
             });
 
@@ -191,7 +195,9 @@ describe('SessionService', () => {
 
                 mockPrisma.listaEspera.findUnique.mockResolvedValue(undefined);
 
-                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(BadRequestException);
+                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(
+                    BadRequestException,
+                );
             });
 
             it('should throw BadRequestException when patient is with final status', async () => {
@@ -211,7 +217,9 @@ describe('SessionService', () => {
 
                 mockPrisma.listaEspera.findUnique.mockResolvedValue(patient);
 
-                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(BadRequestException);
+                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(
+                    BadRequestException,
+                );
             });
 
             it('should throw BadRequestException when session type is wrong', async () => {
@@ -231,7 +239,9 @@ describe('SessionService', () => {
 
                 mockPrisma.listaEspera.findUnique.mockResolvedValue(patient);
 
-                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(BadRequestException);
+                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(
+                    BadRequestException,
+                );
             });
 
             it('should throw BadRequestException when intern is not found', async () => {
@@ -252,7 +262,9 @@ describe('SessionService', () => {
                 mockPrisma.listaEspera.findUnique.mockResolvedValue(patient);
                 mockPrisma.usuario.findUnique.mockResolvedValueOnce(undefined);
 
-                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(BadRequestException);
+                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(
+                    BadRequestException,
+                );
             });
 
             it('should throw BadRequestException when supervisor is not found', async () => {
@@ -279,7 +291,9 @@ describe('SessionService', () => {
                 mockPrisma.usuario.findUnique.mockResolvedValueOnce(intern);
                 mockPrisma.usuario.findUnique.mockResolvedValueOnce(undefined);
 
-                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(BadRequestException);
+                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(
+                    BadRequestException,
+                );
             });
 
             it('should throw BadRequestException when intern already has a session at the same time (overlap)', async () => {
@@ -312,7 +326,9 @@ describe('SessionService', () => {
                 mockPrisma.usuario.findUnique.mockResolvedValueOnce(supervisor);
                 mockPrisma.atendimento.findFirst.mockResolvedValue({ id_Atendimento: 'uuid-conflict' });
 
-                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(BadRequestException);
+                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(
+                    BadRequestException,
+                );
             });
 
             it('should throw BadRequestException when start date is beyond the final date', async () => {
@@ -344,7 +360,9 @@ describe('SessionService', () => {
                 mockPrisma.usuario.findUnique.mockResolvedValueOnce(intern);
                 mockPrisma.usuario.findUnique.mockResolvedValueOnce(supervisor);
 
-                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(BadRequestException);
+                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(
+                    BadRequestException,
+                );
             });
 
             it('should throw BadRequestException when date is from the past', async () => {
@@ -376,7 +394,9 @@ describe('SessionService', () => {
                 mockPrisma.usuario.findUnique.mockResolvedValueOnce(intern);
                 mockPrisma.usuario.findUnique.mockResolvedValueOnce(supervisor);
 
-                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(BadRequestException);
+                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(
+                    BadRequestException,
+                );
             });
 
             it('should throw BadRequestException when intern is not active', async () => {
@@ -402,7 +422,9 @@ describe('SessionService', () => {
                 mockPrisma.listaEspera.findUnique.mockResolvedValue(patient);
                 mockPrisma.usuario.findUnique.mockResolvedValueOnce(intern);
 
-                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(BadRequestException);
+                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(
+                    BadRequestException,
+                );
             });
 
             it('should throw BadRequestException when intern is not with intern role', async () => {
@@ -428,7 +450,9 @@ describe('SessionService', () => {
                 mockPrisma.listaEspera.findUnique.mockResolvedValue(patient);
                 mockPrisma.usuario.findUnique.mockResolvedValueOnce(intern);
 
-                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(BadRequestException);
+                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(
+                    BadRequestException,
+                );
             });
 
             it('should throw BadRequestException when supervisor is not active', async () => {
@@ -460,7 +484,9 @@ describe('SessionService', () => {
                 mockPrisma.usuario.findUnique.mockResolvedValueOnce(intern);
                 mockPrisma.usuario.findUnique.mockResolvedValueOnce(supervisor);
 
-                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(BadRequestException);
+                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(
+                    BadRequestException,
+                );
             });
 
             it('should throw BadRequestException when supervisor is not with supervisor role', async () => {
@@ -492,7 +518,9 @@ describe('SessionService', () => {
                 mockPrisma.usuario.findUnique.mockResolvedValueOnce(intern);
                 mockPrisma.usuario.findUnique.mockResolvedValueOnce(supervisor);
 
-                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(BadRequestException);
+                await expect(service.create(sessionToBeCreated as CreateSessionDto)).rejects.toThrow(
+                    BadRequestException,
+                );
             });
         });
 
@@ -508,7 +536,9 @@ describe('SessionService', () => {
 
                     const result = await service.findAll(user, pagination);
 
-                    expect(mockPrisma.atendimento.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: {} }));
+                    expect(mockPrisma.atendimento.findMany).toHaveBeenCalledWith(
+                        expect.objectContaining({ where: {} }),
+                    );
                     expect(result).toEqual({
                         data: sessions,
                         meta: { total: 1, page: 1, limit: 20, totalPages: 1 },

--- a/apps/backend/src/session/session.service.ts
+++ b/apps/backend/src/session/session.service.ts
@@ -80,7 +80,7 @@ export class SessionService {
     constructor(
         private prisma: PrismaService,
         private cryptoService: CryptoService,
-    ) { }
+    ) {}
 
     /**
      * Descriptografa o conteudo de um prontuário.
@@ -110,35 +110,41 @@ export class SessionService {
             throw new BadRequestException('Paciente não encontrado.');
         }
 
-        const statusFinais = [StatusListaEspera.RECEBEU_ALTA, StatusListaEspera.ENCAMINHADO, StatusListaEspera.DESATIVADO];
+        const statusFinais = [
+            StatusListaEspera.RECEBEU_ALTA,
+            StatusListaEspera.ENCAMINHADO,
+            StatusListaEspera.DESATIVADO,
+        ];
         if (statusFinais.includes(paciente.id_Status)) {
             throw new BadRequestException('Paciente está com um status final e não pode ter novas sessões agendadas.');
         }
 
         if (
-            (session.id_Tipo_Atendimento as TipoAtendimento) !== TipoAtendimento.TRIAGEM &&
-            (session.id_Tipo_Atendimento as TipoAtendimento) !== TipoAtendimento.PSICOTERAPIA
+            session.id_Tipo_Atendimento !== TipoAtendimento.TRIAGEM &&
+            session.id_Tipo_Atendimento !== TipoAtendimento.PSICOTERAPIA
         ) {
             throw new BadRequestException('Tipo de atendimento inválido.');
         }
 
-        if ((session.id_Tipo_Atendimento as TipoAtendimento) === TipoAtendimento.TRIAGEM) {
+        if (session.id_Tipo_Atendimento === TipoAtendimento.TRIAGEM) {
             // 1 = Triagem
-            if ((paciente.id_Status as StatusListaEspera) !== StatusListaEspera.EM_ESPERA) {
-                throw new BadRequestException('Este paciente não está "Em Espera". Não é possível agendar uma nova triagem.');
+            if (paciente.id_Status !== StatusListaEspera.EM_ESPERA) {
+                throw new BadRequestException(
+                    'Este paciente não está "Em Espera". Não é possível agendar uma nova triagem.',
+                );
             }
-        } else if ((session.id_Tipo_Atendimento as TipoAtendimento) === TipoAtendimento.PSICOTERAPIA) {
+        } else if (session.id_Tipo_Atendimento === TipoAtendimento.PSICOTERAPIA) {
             // 2 = Psicoterapia
 
             const statusPermitidos = [StatusListaEspera.TRIAGEM_APROVADA, StatusListaEspera.EM_PSICOTERAPIA];
 
-            if (!statusPermitidos.includes(paciente.id_Status as StatusListaEspera)) {
-                if ((paciente.id_Status as StatusListaEspera) === StatusListaEspera.EM_ESPERA) {
+            if (!statusPermitidos.includes(paciente.id_Status)) {
+                if (paciente.id_Status === StatusListaEspera.EM_ESPERA) {
                     throw new BadRequestException(
                         'Paciente precisa passar pela triagem antes de agendar uma sessão de psicoterapia.',
                     );
                 }
-                if ((paciente.id_Status as StatusListaEspera) === StatusListaEspera.EM_TRIAGEM) {
+                if (paciente.id_Status === StatusListaEspera.EM_TRIAGEM) {
                     throw new BadRequestException(
                         'Paciente está em triagem. A triagem precisa ser aprovada antes de agendar uma sessão de psicoterapia.',
                     );
@@ -154,7 +160,7 @@ export class SessionService {
 
         if (!estagiario) {
             throw new BadRequestException('Estagiário não encontrado.');
-        } else if ((estagiario.roleId as RoleAccess) !== RoleAccess.ESTAGIARIO) {
+        } else if (estagiario.roleId !== RoleAccess.ESTAGIARIO) {
             throw new BadRequestException('O usuário designado como estagiário não possui o papel de estagiário.');
         } else if (!estagiario.isActive) {
             throw new BadRequestException('O estagiário designado está desativado.');
@@ -165,7 +171,7 @@ export class SessionService {
         });
         if (!supervisor) {
             throw new BadRequestException('Supervisor não encontrado.');
-        } else if ((supervisor.roleId as RoleAccess) !== RoleAccess.SUPERVISOR) {
+        } else if (supervisor.roleId !== RoleAccess.SUPERVISOR) {
             throw new BadRequestException('O usuário designado como supervisor não possui o papel de supervisor.');
         } else if (!supervisor.isActive) {
             throw new BadRequestException('O supervisor designado está desativado.');
@@ -220,14 +226,14 @@ export class SessionService {
 
         let updateListaEsperaPromise: Prisma.PrismaPromise<unknown> | null = null;
 
-        if ((session.id_Tipo_Atendimento as TipoAtendimento) === TipoAtendimento.TRIAGEM) {
+        if (session.id_Tipo_Atendimento === TipoAtendimento.TRIAGEM) {
             updateListaEsperaPromise = this.prisma.listaEspera.update({
                 where: { id_Lista: session.id_Lista },
                 data: { id_Status: StatusListaEspera.EM_TRIAGEM },
             });
         } else if (
-            (session.id_Tipo_Atendimento as TipoAtendimento) === TipoAtendimento.PSICOTERAPIA &&
-            (paciente.id_Status as StatusListaEspera) === StatusListaEspera.TRIAGEM_APROVADA
+            session.id_Tipo_Atendimento === TipoAtendimento.PSICOTERAPIA &&
+            paciente.id_Status === StatusListaEspera.TRIAGEM_APROVADA
         ) {
             updateListaEsperaPromise = this.prisma.listaEspera.update({
                 where: { id_Lista: session.id_Lista },
@@ -417,18 +423,18 @@ export class SessionService {
             throw new NotFoundException('Sessão não encontrada.');
         }
 
-        if ((session.id_Status as StatusAtendimento) !== StatusAtendimento.ATIVO) {
+        if (session.id_Status !== StatusAtendimento.ATIVO) {
             throw new BadRequestException('Só é possível cancelar uma sessão que esteja agendada.');
         }
 
         let updateListaEsperaPromise: Prisma.PrismaPromise<unknown> | null = null;
-        if ((session.id_Tipo_Atendimento as TipoAtendimento) === TipoAtendimento.TRIAGEM) {
+        if (session.id_Tipo_Atendimento === TipoAtendimento.TRIAGEM) {
             // Se cancelou uma triagem, paciente volta para "Em espera"
             updateListaEsperaPromise = this.prisma.listaEspera.update({
                 where: { id_Lista: session.id_Lista },
                 data: { id_Status: StatusListaEspera.EM_ESPERA },
             });
-        } else if ((session.id_Tipo_Atendimento as TipoAtendimento) === TipoAtendimento.PSICOTERAPIA) {
+        } else if (session.id_Tipo_Atendimento === TipoAtendimento.PSICOTERAPIA) {
             const hasOtherPsicoterapia = await this.prisma.prontuario.findFirst({
                 where: {
                     atendimento: {

--- a/apps/backend/src/users/dto/create-user.dto.ts
+++ b/apps/backend/src/users/dto/create-user.dto.ts
@@ -22,13 +22,19 @@ export class CreateUserDto {
     @MaxLength(255)
     senha: string;
 
-    @ApiProperty({ example: 4, description: 'ID do perfil de acesso: 1=Coordenador, 2=Secretário, 3=Supervisor, 4=Estagiário' })
+    @ApiProperty({
+        example: 4,
+        description: 'ID do perfil de acesso: 1=Coordenador, 2=Secretário, 3=Supervisor, 4=Estagiário',
+    })
     @IsInt()
     @Min(1)
     @Transform(({ value }: { value: string }) => parseInt(value))
     roleId: number;
 
-    @ApiPropertyOptional({ example: '06/12345', description: 'CRP do supervisor no formato XX/XXXXX ou XX/XXXXXX. Obrigatório quando roleId=3.' })
+    @ApiPropertyOptional({
+        example: '06/12345',
+        description: 'CRP do supervisor no formato XX/XXXXX ou XX/XXXXXX. Obrigatório quando roleId=3.',
+    })
     @IsOptional()
     @IsString({ message: 'O CRP deve ser um texto.' })
     @IsNotEmpty({ message: 'O campo CRP não pode ser vazio.' })

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -31,7 +31,7 @@ import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 @Controller('users')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class UsersController {
-    constructor(private readonly usersService: UsersService) { }
+    constructor(private readonly usersService: UsersService) {}
 
     @ApiOperation({ summary: 'Criar novo usuário' })
     @ApiResponse({ status: 201, description: 'Usuário criado com sucesso.' })

--- a/apps/backend/src/users/users.module.ts
+++ b/apps/backend/src/users/users.module.ts
@@ -9,4 +9,4 @@ import { HashingModule } from 'src/auth/hash/hashing.module';
     controllers: [UsersController],
     providers: [UsersService],
 })
-export class UsersModule { }
+export class UsersModule {}

--- a/apps/backend/src/users/users.service.spec.ts
+++ b/apps/backend/src/users/users.service.spec.ts
@@ -184,7 +184,9 @@ describe('UserService', () => {
                     access: RoleAccess.ADMIN,
                 } as TokenDto;
 
-                const users = [{ id_User: 'uuid-1', nome: 'pedro', email: 'pedro@test.com', roleId: RoleAccess.ESTAGIARIO }];
+                const users = [
+                    { id_User: 'uuid-1', nome: 'pedro', email: 'pedro@test.com', roleId: RoleAccess.ESTAGIARIO },
+                ];
 
                 mockPrisma.usuario.findMany.mockResolvedValue(users);
                 mockPrisma.usuario.count.mockResolvedValue(1);
@@ -203,7 +205,12 @@ describe('UserService', () => {
                 } as TokenDto;
                 const id_choosed = randomUUID();
 
-                const user = { id_User: id_choosed, nome: 'pedro', email: 'pedro@test.com', roleId: RoleAccess.ESTAGIARIO };
+                const user = {
+                    id_User: id_choosed,
+                    nome: 'pedro',
+                    email: 'pedro@test.com',
+                    roleId: RoleAccess.ESTAGIARIO,
+                };
 
                 mockPrisma.usuario.findFirst.mockResolvedValue(user);
                 const result = await service.findOne(id_choosed, creator);
@@ -259,7 +266,9 @@ describe('UserService', () => {
                 };
 
                 mockPrisma.usuario.findUnique.mockResolvedValue(undefined);
-                await expect(service.update('uuid-1' as UUID, dataToUpdate, creator)).rejects.toThrow(NotFoundException);
+                await expect(service.update('uuid-1' as UUID, dataToUpdate, creator)).rejects.toThrow(
+                    NotFoundException,
+                );
             });
 
             it('should throw ForbiddenException when a user (supervisor or intern) try to update another with grater role than his and different account than theirs', async () => {
@@ -280,7 +289,9 @@ describe('UserService', () => {
                 };
 
                 mockPrisma.usuario.findUnique.mockResolvedValue(user);
-                await expect(service.update('uuid-1' as UUID, dataToUpdate, creator)).rejects.toThrow(ForbiddenException);
+                await expect(service.update('uuid-1' as UUID, dataToUpdate, creator)).rejects.toThrow(
+                    ForbiddenException,
+                );
             });
 
             it('should throw BadRequestException when a user try to update but already has an existing email', async () => {
@@ -310,7 +321,9 @@ describe('UserService', () => {
                 mockPrisma.usuario.findUnique.mockResolvedValue(user);
                 mockPrisma.usuario.findFirst.mockResolvedValue(userFinded);
 
-                await expect(service.update('uuid-1' as UUID, dataToUpdate, creator)).rejects.toThrow(BadRequestException);
+                await expect(service.update('uuid-1' as UUID, dataToUpdate, creator)).rejects.toThrow(
+                    BadRequestException,
+                );
             });
 
             it('should throw ConflictException when a user try to update another but already has an existing email and creator can reactive', async () => {
@@ -340,7 +353,9 @@ describe('UserService', () => {
                 mockPrisma.usuario.findUnique.mockResolvedValue(user);
                 mockPrisma.usuario.findFirst.mockResolvedValue(userFinded);
 
-                await expect(service.update('uuid-1' as UUID, dataToUpdate, creator)).rejects.toThrow(ConflictException);
+                await expect(service.update('uuid-1' as UUID, dataToUpdate, creator)).rejects.toThrow(
+                    ConflictException,
+                );
             });
         });
 

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -20,20 +20,14 @@ export class UsersService {
     constructor(
         private prisma: PrismaService,
         private HashingService: HashingServiceProtocol,
-    ) { }
+    ) {}
 
     private canActOnUser(actorAccess: number, targetRoleId: number): boolean {
-        return (
-            actorAccess < targetRoleId ||
-            ((actorAccess as RoleAccess) === RoleAccess.ADMIN && (targetRoleId as RoleAccess) === RoleAccess.ADMIN)
-        );
+        return actorAccess < targetRoleId || (actorAccess === RoleAccess.ADMIN && targetRoleId === RoleAccess.ADMIN);
     }
 
     async create(createUserDto: CreateUserDto, creator: TokenDto) {
-        if (
-            (createUserDto.roleId as RoleAccess) <= creator.access &&
-            !this.canActOnUser(creator.access, createUserDto.roleId)
-        ) {
+        if (createUserDto.roleId <= creator.access && !this.canActOnUser(creator.access, createUserDto.roleId)) {
             throw new ForbiddenException(
                 'Você não tem permissão para criar um usuário com nível de acesso igual ou superior ao seu.',
             );
@@ -51,8 +45,8 @@ export class UsersService {
             }
 
             const canReactivate =
-                creator.access < (existingUser.roleId as RoleAccess) ||
-                (creator.access === RoleAccess.ADMIN && (existingUser.roleId as RoleAccess) === RoleAccess.ADMIN);
+                creator.access < existingUser.roleId ||
+                (creator.access === RoleAccess.ADMIN && existingUser.roleId === RoleAccess.ADMIN);
 
             if (canReactivate) {
                 throw new ConflictException({
@@ -65,7 +59,7 @@ export class UsersService {
             }
         }
 
-        if ((createUserDto.roleId as RoleAccess) === RoleAccess.SUPERVISOR) {
+        if (createUserDto.roleId === RoleAccess.SUPERVISOR) {
             if (!createUserDto.crp) {
                 throw new BadRequestException('CRP é obrigatório para psicólogos supervisores.');
             }
@@ -193,7 +187,7 @@ export class UsersService {
         };
 
         if (updateUserDto.crp !== undefined) {
-            if ((user.roleId as RoleAccess) !== RoleAccess.SUPERVISOR) {
+            if (user.roleId !== RoleAccess.SUPERVISOR) {
                 throw new BadRequestException(
                     'O campo CRP (Conselho Regional de Psicologia) só pode ser definido para usuários do tipo Supervisor.',
                 );
@@ -257,7 +251,7 @@ export class UsersService {
             throw new BadRequestException('Este usuário já está ativo.');
         }
 
-        if (creator.access >= (user.roleId as RoleAccess) && creator.access !== RoleAccess.ADMIN) {
+        if (creator.access >= user.roleId && creator.access !== RoleAccess.ADMIN) {
             throw new ForbiddenException('Você não tem permissão para reativar um usuário deste nível de acesso.');
         }
 

--- a/apps/backend/src/waitlist/dto/update-waitlist.dto.ts
+++ b/apps/backend/src/waitlist/dto/update-waitlist.dto.ts
@@ -1,4 +1,4 @@
 import { PartialType } from '@nestjs/swagger';
 import { CreateWaitlistDto } from './create-waitlist.dto';
 
-export class UpdateWaitlistDto extends PartialType(CreateWaitlistDto) { }
+export class UpdateWaitlistDto extends PartialType(CreateWaitlistDto) {}

--- a/apps/backend/src/waitlist/entities/waitlist.entity.ts
+++ b/apps/backend/src/waitlist/entities/waitlist.entity.ts
@@ -1,1 +1,1 @@
-export class Waitlist { }
+export class Waitlist {}

--- a/apps/backend/src/waitlist/waitlist.controller.ts
+++ b/apps/backend/src/waitlist/waitlist.controller.ts
@@ -11,7 +11,7 @@ import { PaginationDto } from 'src/common/dto/pagination.dto';
 @ApiTags('Lista de Espera')
 @Controller('waitlist')
 export class WaitlistController {
-    constructor(private readonly waitlistService: WaitlistService) { }
+    constructor(private readonly waitlistService: WaitlistService) {}
 
     @ApiOperation({ summary: 'Cadastro público de paciente na lista de espera' })
     @ApiResponse({ status: 201, description: 'Paciente cadastrado. Retorna UUID para consulta de posição.' })

--- a/apps/backend/src/waitlist/waitlist.module.ts
+++ b/apps/backend/src/waitlist/waitlist.module.ts
@@ -8,4 +8,4 @@ import { PrismaModule } from 'src/prisma/prisma.module';
     controllers: [WaitlistController],
     providers: [WaitlistService],
 })
-export class WaitlistModule { }
+export class WaitlistModule {}

--- a/apps/backend/src/waitlist/waitlist.service.spec.ts
+++ b/apps/backend/src/waitlist/waitlist.service.spec.ts
@@ -84,7 +84,10 @@ describe('WaitlistService', () => {
                     id_Escolaridade: 1,
                 } as CreateWaitlistDto;
 
-                mockPrisma.listaEspera.findFirst.mockResolvedValue({ id_Lista: 'uuid-existente', CPF: '123.456.789-00' });
+                mockPrisma.listaEspera.findFirst.mockResolvedValue({
+                    id_Lista: 'uuid-existente',
+                    CPF: '123.456.789-00',
+                });
                 await expect(service.create(body)).rejects.toThrow(BadRequestException);
             });
         });

--- a/apps/backend/src/waitlist/waitlist.service.ts
+++ b/apps/backend/src/waitlist/waitlist.service.ts
@@ -16,7 +16,7 @@ import { paginate, PaginationDto } from 'src/common/dto/pagination.dto';
 export class WaitlistService {
     private readonly logger = new Logger(WaitlistService.name);
 
-    constructor(private prisma: PrismaService) { }
+    constructor(private prisma: PrismaService) {}
 
     async create(body: CreateWaitlistDto) {
         const existingActiveEntry = await this.prisma.listaEspera.findFirst({
@@ -34,7 +34,9 @@ export class WaitlistService {
         });
 
         if (existingActiveEntry)
-            throw new BadRequestException('Já existe uma entrada ativa na lista de espera com este CPF. Contate a equipe');
+            throw new BadRequestException(
+                'Já existe uma entrada ativa na lista de espera com este CPF. Contate a equipe',
+            );
 
         const newWaitlistEntry = await this.prisma.listaEspera.create({
             data: {
@@ -98,7 +100,7 @@ export class WaitlistService {
         return {
             ...waitlistEntry,
             posicaoNaLista: posicao,
-            situacao: (waitlistEntry.id_Status as StatusListaEspera) === StatusListaEspera.EM_ESPERA ? 'Ativo' : 'Inativo',
+            situacao: waitlistEntry.id_Status === StatusListaEspera.EM_ESPERA ? 'Ativo' : 'Inativo',
         };
     }
 
@@ -128,7 +130,7 @@ export class WaitlistService {
         return {
             ...waitlistEntry,
             posicaoNaLista: posicaoNaLista + 1,
-            situacao: (waitlistEntry.id_Status as StatusListaEspera) === StatusListaEspera.EM_ESPERA ? 'Ativo' : 'Inativo',
+            situacao: waitlistEntry.id_Status === StatusListaEspera.EM_ESPERA ? 'Ativo' : 'Inativo',
         };
     }
 
@@ -210,25 +212,27 @@ export class WaitlistService {
         if (!waitlistEntry) {
             throw new NotFoundException('Paciente não encontrado na lista de espera.');
         }
-        if ((waitlistEntry.id_Status as StatusListaEspera) === StatusListaEspera.DESATIVADO) {
+        if (waitlistEntry.id_Status === StatusListaEspera.DESATIVADO) {
             throw new BadRequestException('Paciente já está desativado na lista de espera.');
         }
         if (
-            (waitlistEntry.id_Status as StatusListaEspera) === StatusListaEspera.RECEBEU_ALTA ||
-            (waitlistEntry.id_Status as StatusListaEspera) === StatusListaEspera.ENCAMINHADO
+            waitlistEntry.id_Status === StatusListaEspera.RECEBEU_ALTA ||
+            waitlistEntry.id_Status === StatusListaEspera.ENCAMINHADO
         ) {
-            throw new BadRequestException('Não é possível desativar um paciente que já recebeu alta ou foi encaminhado.');
+            throw new BadRequestException(
+                'Não é possível desativar um paciente que já recebeu alta ou foi encaminhado.',
+            );
         }
-        if ((waitlistEntry.id_Status as StatusListaEspera) === StatusListaEspera.EM_PSICOTERAPIA) {
+        if (waitlistEntry.id_Status === StatusListaEspera.EM_PSICOTERAPIA) {
             throw new BadRequestException('Não é possível desativar um paciente que está em psicoterapia.');
         }
-        if ((waitlistEntry.id_Status as StatusListaEspera) === StatusListaEspera.TRIAGEM_APROVADA) {
+        if (waitlistEntry.id_Status === StatusListaEspera.TRIAGEM_APROVADA) {
             throw new BadRequestException('Não é possível desativar um paciente com triagem aprovada');
         }
-        if ((waitlistEntry.id_Status as StatusListaEspera) === StatusListaEspera.EM_TRIAGEM) {
+        if (waitlistEntry.id_Status === StatusListaEspera.EM_TRIAGEM) {
             throw new BadRequestException('Não é possível desativar um paciente que está em triagem.');
         }
-        if ((waitlistEntry.id_Status as StatusListaEspera) !== StatusListaEspera.EM_ESPERA) {
+        if (waitlistEntry.id_Status !== StatusListaEspera.EM_ESPERA) {
             throw new BadRequestException('Apenas pacientes com status "Em espera" podem ser desativados.');
         }
 

--- a/apps/backend/test/access-control.e2e-spec.ts
+++ b/apps/backend/test/access-control.e2e-spec.ts
@@ -46,23 +46,22 @@ describe('Access Control (e2e)', () => {
         ).body.token;
 
         estagiario2 = (
-            await request(server)
-                .post('/users')
-                .set('Authorization', `Bearer ${adminToken}`)
-                .send({ nome: 'Estagiario 2 E2E', email: 'estagiario2@e2e.com', senha: 'Est2E2E123!', roleId: RoleAccess.ESTAGIARIO })
+            await request(server).post('/users').set('Authorization', `Bearer ${adminToken}`).send({
+                nome: 'Estagiario 2 E2E',
+                email: 'estagiario2@e2e.com',
+                senha: 'Est2E2E123!',
+                roleId: RoleAccess.ESTAGIARIO,
+            })
         ).body;
 
         supervisor2 = (
-            await request(server)
-                .post('/users')
-                .set('Authorization', `Bearer ${adminToken}`)
-                .send({
-                    nome: 'Supervisor 2 E2E',
-                    email: 'supervisor2@e2e.com',
-                    senha: 'Sup2E2E123!',
-                    roleId: RoleAccess.SUPERVISOR,
-                    crp: '06/99999',
-                })
+            await request(server).post('/users').set('Authorization', `Bearer ${adminToken}`).send({
+                nome: 'Supervisor 2 E2E',
+                email: 'supervisor2@e2e.com',
+                senha: 'Sup2E2E123!',
+                roleId: RoleAccess.SUPERVISOR,
+                crp: '06/99999',
+            })
         ).body;
 
         estagiario1 = await prisma.usuario.findFirstOrThrow({ where: { email: 'estagiario@arca.com' } });

--- a/apps/backend/test/auth.e2e-spec.ts
+++ b/apps/backend/test/auth.e2e-spec.ts
@@ -50,6 +50,9 @@ describe('Auth (e2e)', () => {
             .send({ email: 'admin@arca.com', password: 'Admin123!' })
             .expect(200);
 
-        await request(app.getHttpServer()).get('/users').set('Authorization', `Bearer ${loginRes.body.token}`).expect(200);
+        await request(app.getHttpServer())
+            .get('/users')
+            .set('Authorization', `Bearer ${loginRes.body.token}`)
+            .expect(200);
     });
 });


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` (`* text=auto eol=lf`) so Windows checkouts stop flipping tracked files to CRLF, which was making Prettier flag `Delete ␍` on nearly every line of every file.
- Excludes `coverage/**` and `jest.config.js` from `eslint.config.mjs` — they aren't part of the TS project, so type-aware linting failed to parse them.
- Runs `eslint --fix` across `apps/backend` to clear formatting drift accumulated since `.prettierrc`'s `tabWidth` moved from 2 to 4.
- Fixes `pdf.service.ts`: the installed `puppeteer` (24.43.1) no longer accepts `'networkidle0'` in `page.setContent()`; switched to `'load'`. This was crashing the whole Jest run via a TS type error in `medical_record.service.spec.ts`.

## Test plan
- [x] `npx eslint .` in `apps/backend` — 0 CRLF/parsing errors (only pre-existing style warnings remain)
- [x] `npx jest` in `apps/backend` — 8/8 suites, 136/136 tests passing