### PR TITLE
Aplica documentação pendente e melhorias não-tenant do trabalho do #107

### DIFF
--- a/apps/backend/prisma.config.ts
+++ b/apps/backend/prisma.config.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { defineConfig } from 'prisma/config';
 
 export default defineConfig({
@@ -5,5 +6,6 @@ export default defineConfig({
     engine: 'classic',
     datasource: {
         url: process.env.DATABASE_URL!,
+        directUrl: process.env.DIRECT_URL,
     },
 });

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -164,7 +164,7 @@ async function main() {
             email: 'supervisor@arca.com',
             senha: 'Supervisor123!',
             roleId: RoleAccess.SUPERVISOR,
-            CRP: 'CRP-123456',
+            CRP: '123456',
             description: 'Usuário supervisor',
         },
         {

--- a/apps/backend/src/auth/auth.service.spec.ts
+++ b/apps/backend/src/auth/auth.service.spec.ts
@@ -100,10 +100,6 @@ describe('AuthService', () => {
 
             const result = await service.login(user);
             expect(result).toEqual({
-                id: user.id_User,
-                name: user.nome,
-                email: user.email,
-                roleId: user.roleId,
                 token: 'token-fake',
             });
         });

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -61,10 +61,6 @@ export class AuthService {
         );
 
         return {
-            id: user.id_User,
-            name: user.nome,
-            email: user.email,
-            roleId: user.roleId,
             token: token,
         };
     }

--- a/apps/backend/src/auth/dto/authenticated-user.dto.ts
+++ b/apps/backend/src/auth/dto/authenticated-user.dto.ts
@@ -1,7 +1,3 @@
 export interface AuthenticatedUserDto {
-    id: string;
-    name: string;
-    email: string;
-    roleId: number;
     token: string;
 }

--- a/docs/ARQUITETURA.md
+++ b/docs/ARQUITETURA.md
@@ -3,7 +3,6 @@
 Este documento é o mapa único do projeto: o que é, como está construído, o que já existe e o que falta. Se você está chegando agora — como colaborador ou voltando depois de um tempo parado — comece por aqui, não pelo Swagger. O Swagger mostra os endpoints; este documento mostra por que eles existem e como se encaixam.
 
 Documentação relacionada:
-
 - `README.md` — como instalar e rodar o projeto localmente
 - `CLAUDE.md` — referência técnica rápida para sessões de desenvolvimento assistido (comandos, estrutura de pastas)
 - `docs/adr/` — o histórico de decisões de arquitetura, uma por arquivo, nunca reescritas (só substituídas por uma ADR nova quando a decisão muda)
@@ -17,7 +16,7 @@ Nasceu como TCC, mas é tratado como produto comercial real desde então — dec
 ## 2. Stack e por que essas escolhas
 
 | Camada | Tecnologia | Por quê |
-| --- | --- | --- |
+|---|---|---|
 | Backend | NestJS + Prisma + PostgreSQL | Tipagem forte ponta a ponta, migrations versionadas, estrutura modular que escala bem pra um time pequeno |
 | Frontend | Next.js 15 (App Router) + Server Actions | Sem camada de API intermediária no frontend — Server Actions falam direto com o backend, menos código de integração pra manter |
 | Monorepo | Turborepo | Backend e frontend num repo só, cache de build compartilhado |
@@ -26,22 +25,130 @@ Nasceu como TCC, mas é tratado como produto comercial real desde então — dec
 
 ## 3. Como as peças se encaixam
 
-```text
+```
 Usuário → Next.js (Server Actions) → NestJS API → Prisma → PostgreSQL (Supabase)
                 ↓
            NextAuth (sessão, JWT)
 ```
 
 Decisões travadas para o frontend (detalhe completo no `CLAUDE.md`):
-
 - Toda leitura/escrita de dado passa por Server Action, nunca por hook client-side batendo direto na API
 - Route Handlers existem só para o NextAuth
 - Nenhuma env var `NEXT_PUBLIC_` além do que o NextAuth exige
 - App autenticado vive em `/plataforma/*`, dentro do route group `(auth)`; rotas públicas ficam em `(external)`
 
+### 3.1 Roteamento multi-tenant (control plane)
+
+A ADR 0006 decidiu banco de dados físico isolado por clínica (não mais schema único com RLS — ver nota na Seção 4). Isso exige resolver, a cada request, qual banco atender, sem precisar de um deploy de backend por clínica:
+
+```mermaid
+flowchart TD
+    Client["Cliente (browser)"] -->|"HTTPS"| Frontend["Next.js — Server Actions"]
+    Frontend -->|"JWT (clinicaId) ou slug público"| API["NestJS API (deploy único)"]
+
+    API --> Resolver["Tenant Resolver (Guard)<br/>lê clinicaId do JWT<br/>ou slug da rota pública"]
+
+    Resolver --> Cache{"PrismaClient já<br/>cacheado pra essa clínica?"}
+
+    Cache -->|"sim (cache hit)"| Services["Serviços de domínio<br/>Waitlist · Session · MedicalRecord · Audit"]
+
+    Cache -->|"não (cache miss)"| CPLookup["busca connectionString<br/>no Control Plane"]
+    CPLookup --> ControlPlaneDB[("Control Plane DB<br/>registry de clínicas<br/>sem dado de paciente")]
+    ControlPlaneDB --> Decrypt["descriptografa a string<br/>(CryptoService)"]
+    Decrypt --> NewClient["instancia PrismaClient novo<br/>cacheia (LRU evita se cheio)"]
+    NewClient --> Services
+
+    Services --> Redis["Redis<br/>cache-aside p/ leituras públicas<br/>(ex: posição na waitlist, TTL curto)"]
+    Redis -->|"cache hit — não toca Postgres"| Response(["Resposta"])
+    Redis -->|"cache miss ou escrita"| Pooler["Pooler (PgBouncer)<br/>opcional — multiplexa conexões"]
+    Pooler -.->|"popula / invalida"| Redis
+
+    subgraph PG["Instância Postgres compartilhada"]
+        Pooler --> DBA[("clinica_a")]
+        Pooler --> DBB[("clinica_b")]
+        Pooler --> DBN[("clinica_n")]
+    end
+```
+
+O Redis é especialmente relevante na rota pública de consulta de posição na waitlist (sem autenticação, mesmo paciente reconsultando o próprio status repetidamente) — evita que esse tráfego acorde o `PrismaClient`/pool da clínica a cada request. É complementar ao cache de `PrismaClient` por tenant, não um substituto: reduz volume/duração de query por conexão, não a quantidade de pools abertos.
+
+Detalhe completo (control plane, provisionamento, limites de conexão) na ADR 0006.
+
 ## 4. Modelo de domínio
 
-O diagrama abaixo é o núcleo relacional do sistema. Os campos `id_Clinica` marcados representam o estado **planejado** (ver ADR 0001) — ainda não implementados no banco atual.
+A arquitetura atual (ADR 0006) é **banco de dados físico isolado por clínica**: cada clínica tem seu próprio banco Postgres, com o schema de domínio replicado nele — não existe mais uma tabela `Clinica`/coluna `id_Clinica` dentro do banco de domínio, porque o próprio banco já é a fronteira de tenant. A identidade da clínica vive num banco separado, o control plane.
+
+### 4.1 Schema replicado em cada banco de clínica (atual)
+
+```mermaid
+erDiagram
+  ROLE ||--o{ USUARIO : define
+  LISTA_ESPERA ||--o{ ATENDIMENTO : origina
+  ATENDIMENTO ||--o{ PRONTUARIO : gera
+  USUARIO ||--o{ LOG_AUDITORIA : executa
+
+  USUARIO {
+    uuid id_User PK
+    string nome
+    string email
+    int roleId FK
+    string CRP
+  }
+  ROLE {
+    int id_Role PK
+    string role
+  }
+  LISTA_ESPERA {
+    uuid id_Lista PK
+    string nomeRegistro
+    string CPF
+    int id_Status FK
+  }
+  ATENDIMENTO {
+    uuid id_Atendimento PK
+    uuid id_Lista FK
+    uuid id_Estagiario_Executor FK
+    uuid id_Supervisor_Executor FK
+    int id_Status FK
+  }
+  PRONTUARIO {
+    uuid id_Registro PK
+    uuid id_Atendimento FK
+    string conteudo
+    int id_Tipo FK
+  }
+  LOG_AUDITORIA {
+    uuid id_Log PK
+    uuid id_Usuario_Executor FK
+    string tipoAcao
+  }
+```
+
+Fora do diagrama por clareza: tabelas de apoio (`Genero`, `Etnia`, `Escolaridade`, `StatusListaEspera`, `StatusAtendimento`, `TipoAtendimento`, `StatusProntuario`, `TipoProntuario`). Sob o modelo anterior (schema único) eram lookups compartilhados entre clínicas; sob o modelo atual, como cada clínica tem seu próprio banco, essas tabelas passam a ser semeadas (`prisma db seed`) em cada banco de clínica individualmente — não há mais nada literalmente compartilhado entre bancos.
+
+### 4.2 Control Plane DB (registry de tenants)
+
+Banco separado de todos os bancos de clínica, sem dado de paciente — só o necessário para resolver, a cada request, qual banco atender (ver Seção 3.1 e ADR 0006):
+
+```mermaid
+erDiagram
+  CLINICA {
+    uuid id_Clinica PK
+    string slug
+    string nome
+    string connectionString "criptografada em repouso"
+    string status "provisionando · ativa · suspensa"
+    string schemaVersion
+    string region
+    datetime createdAt
+  }
+```
+
+### 4.3 Histórico: a jornada ADR 0001 → 0005 (schema único com RLS)
+
+Esse não é o caminho ativo — fica registrado aqui porque foi implementado, validado e chegou a ser mergeado antes de a ADR 0006 mudar de direção, e continua valendo como referência técnica de como fazer RLS + Prisma Client Extension corretamente, caso algum cenário futuro volte a justificar schema compartilhado.
+
+O modelo era um único banco compartilhado, com toda tabela de domínio carregando `id_Clinica` e Row-Level Security garantindo o isolamento por linha:
 
 ```mermaid
 erDiagram
@@ -103,7 +210,20 @@ erDiagram
   }
 ```
 
-Fora do diagrama por clareza: tabelas de apoio globais (`Genero`, `Etnia`, `Escolaridade`, `StatusListaEspera`, `StatusAtendimento`, `TipoAtendimento`, `StatusProntuario`, `TipoProntuario`) — são lookups compartilhados entre todas as clínicas, não têm `id_Clinica`.
+Referência completa da implementação: ADR 0001 (decisão), ADR 0004 (implementado, merge adiado), ADR 0005 (merge pra `development`), branch `107-adicionar-modelo-clinica-e-clinicaid-no-schema-adr-001`.
+
+### Roles de banco de dados
+
+O Postgres é acessado por dois roles distintos, com privilégios diferentes:
+
+- **`arca_app`** — role de aplicação, least-privilege. É quem `DATABASE_URL` autentica; o backend NestJS e o `prisma db seed` rodam com esse role. Tem só `USAGE` no schema `public` e `SELECT`/`INSERT`/`UPDATE`/`DELETE` nas tabelas — sem permissão de alterar estrutura (criar/dropar tabela, coluna, etc.).
+- **Role dono do schema** (superuser, ex. `postgres`) — é quem `DIRECT_URL` autentica. Só é usado pelo Prisma Migrate (`migrate dev`/`migrate deploy`/`migrate reset`), inclusive pra criar o shadow database exigido pelo `migrate dev`. Nunca é usado em runtime da aplicação.
+
+Os privilégios de `arca_app` são concedidos via migração normal (`prisma/migrations/20260816214907_grant_arca_app_privileges/`), executada com o role dono do schema — não é um passo manual à parte. Isso significa que um banco novo, rodando só `prisma migrate deploy`, já sai com `arca_app` funcional.
+
+O que a migração **não** faz — de propósito — é criar o role `arca_app` em si (`CREATE ROLE ... PASSWORD ...`). Roles são objetos do cluster Postgres, não do schema de uma aplicação específica, e a senha não pode ir pro Git. Por isso, provisionar `arca_app` (criar o role com login e senha própria por ambiente) é um passo de infraestrutura que precisa acontecer *antes* da primeira migração rodar em qualquer ambiente novo — se não acontecer, a migração de grants falha alto e claro ("role arca_app does not exist") em vez de deixar a aplicação falhar silenciosamente depois, em tempo de query.
+
+Essa separação de roles é a base sobre a qual o enforcement de tenant via Row-Level Security (ADR 0001) vai se apoiar — é o que já existe hoje, mesmo antes do RLS em si estar implementado.
 
 ### Fluxo clínico (o que o sistema modela)
 
@@ -116,7 +236,7 @@ Fora do diagrama por clareza: tabelas de apoio globais (`Genero`, `Etnia`, `Esco
 ### Papéis
 
 | Papel | Acesso |
-| --- | --- |
+|---|---|
 | Coordenador (ADMIN) | Tudo, incluindo auditoria e gestão de usuários |
 | Secretário | Agendamento, lista de espera, visão de fluxo completo |
 | Supervisor | Aprova relatórios de estagiários, gera documentos finais, vê só seus pacientes |
@@ -125,11 +245,11 @@ Fora do diagrama por clareza: tabelas de apoio globais (`Genero`, `Etnia`, `Esco
 ## 5. Status atual
 
 | Área | Status | Observação |
-| --- | --- | --- |
+|---|---|---|
 | Backend — módulos core | ✅ Pronto | auth, users, waitlist, session, medical_record, audit, crypto, pdf |
 | Backend — segurança base | ✅ Pronto | RBAC, rate limiting, helmet, JWT audience/issuer, auditoria global |
-| Backend — multi-tenancy (schema) | 🔜 Planejado | ADR 0001 — issue aberta, ainda não implementado |
-| Backend — enforcement de tenant + RLS | 🔜 Planejado | Depende do item acima |
+| Backend — multi-tenancy (schema único, extension, RLS) | 🟡 Superado pela ADR 0006 | Branch `107-adicionar-modelo-clinica-e-clinicaid-no-schema-adr-001` (ADR 0004/0005) preservada como referência técnica — RLS/CLS não é mais a direção ativa |
+| Backend — multi-tenancy (banco físico por clínica + control plane) | 🔜 Planejado | Direção decidida na ADR 0006; registry de tenants, cache de `PrismaClient` por tenant e fluxo de provisionamento ainda não implementados |
 | Backend — entidades de domínio ricas | 🔜 Planejado | Direção decidida (`Atendimento`, `Prontuario` com `fromPrisma()`), ainda não no código |
 | Frontend — shell da plataforma | ✅ Pronto | Sidebar, proteção de rota, dashboard vazio em `/plataforma` |
 | Frontend — módulos de domínio | ⏳ Não iniciado | Pacientes, atendimentos, waitlist etc. — tracked via milestones M0–M12 no GitHub |
@@ -141,7 +261,12 @@ Um ADR (Architecture Decision Record) registra **uma** decisão: o contexto que 
 
 Ficam em `docs/adr/`, um arquivo por decisão, numerados em ordem (`0001-`, `0002-`...). Existentes:
 
-- `0001-multi-tenancy-estrategia-hibrida.md` — banco único compartilhado com `clinicaId`, ao invés de um banco por clínica
+- `0001-multi-tenancy-estrategia-hibrida.md` — banco único compartilhado com `clinicaId`, ao invés de um banco por clínica — **superada pela 0006**
+- `0002-banco-de-dados-nuvem-gerenciada.md` — **superada pela 0003**
+- `0003-banco-de-dados-producao-em-aberto.md` — self-hosted aceitável em teste; escolha do banco de produção fica em aberto, decidida por custo
+- `0004-multi-tenancy-implementado-merge-adiado.md` — **decisão de adiar o merge superada pela 0005** (e o modelo em si, pela 0006)
+- `0005-multi-tenancy-merge-para-development.md` — merge pra `development` antes da 2ª clínica real, após corrigir dois bugs de isolamento encontrados na revisão — **modelo superado pela 0006**
+- `0006-multi-tenancy-isolamento-fisico-por-banco.md` — banco de dados físico isolado por clínica (mesma instância, bancos e roles separados) via control plane de tenants, substituindo o schema único com RLS das ADRs 0001/0004/0005
 
 Quando surgir uma dúvida do tipo "por que decidimos X" no futuro, a resposta deve estar aqui, não na memória de ninguém.
 

--- a/docs/adr/0002-banco-de-dados-nuvem-gerenciada.md
+++ b/docs/adr/0002-banco-de-dados-nuvem-gerenciada.md
@@ -1,0 +1,60 @@
+# ADR 0002: Banco de Dados em Nuvem Gerenciada, Não Self-Hosted
+
+**Status:** Superado por ADR 0003
+**Data:** 2026-08-14
+
+## Contexto
+
+Ao revisar a stack, surgiu a dúvida se o Postgres deveria continuar em nuvem
+gerenciada (Supabase, já em uso) ou migrar para self-hosted na infraestrutura
+Coolify que a WizeCode já opera.
+
+Ao aprofundar, ficou claro que essa infraestrutura Coolify atual é uma máquina
+residencial: sem redundância, sem segurança além da rede doméstica, e sem
+garantia de disponibilidade — se o hardware falhar, a recuperação depende
+inteiramente de backup. Isso é adequado para ambiente de desenvolvimento e para
+os usos internos atuais da empresa, mas não para armazenar o dado mais sensível
+do sistema.
+
+O ARCA processa prontuário psicológico — dado sensível por definição na LGPD
+(Art. 5º, II), que exige medidas de segurança técnicas e administrativas
+compatíveis (Art. 46). Hospedar esse dado numa máquina doméstica sem
+redundância não atende esse padrão a partir do momento em que exista paciente
+real no sistema.
+
+## Decisão
+
+Manter o banco de dados em nuvem gerenciada — Supabase, já em uso — em vez de
+self-hosted na infraestrutura Coolify atual. Confirmar que o projeto está
+provisionado na região São Paulo, para latência e para manter o processamento
+do dado dentro do Brasil.
+
+Este ADR cobre especificamente o **banco de dados**. Onde a aplicação em si
+(backend e frontend) roda em produção não está decidido aqui — hoje ambos
+também rodam no mesmo Coolify doméstico, e essa é uma decisão maior, separada,
+que precisa ser revisitada antes de o ARCA atender uma clínica real (ver
+Consequências).
+
+## Consequências
+
+**Positivas:**
+- Backup e disponibilidade do dado mais sensível do sistema deixam de depender
+  de uma máquina residencial
+- Zero curva de aprendizado — a solução já está em uso e funcionando
+- Região São Paulo mantém o dado no Brasil
+
+**Negativas / trade-offs:**
+- Dependência de um vendor externo para o componente mais crítico do sistema
+- Custo escala com uso, diferente da infraestrutura própria já paga
+
+**Em aberto (fora do escopo deste ADR):**
+- O backend e o frontend do ARCA ainda rodam na infraestrutura Coolify
+  doméstica. Isso precisa de uma decisão própria sobre onde a aplicação roda em
+  produção — VPS, cloud gerenciada, ou outra opção — antes de qualquer clínica
+  real depender do sistema no ar.
+
+## Alternativas consideradas
+
+- **Self-hosted no Coolify atual**: rejeitado — a infraestrutura real por trás
+  do Coolify hoje (hardware residencial) não oferece garantia de segurança ou
+  disponibilidade compatível com dado sensível de saúde sob LGPD.

--- a/docs/adr/0003-banco-de-dados-producao-em-aberto.md
+++ b/docs/adr/0003-banco-de-dados-producao-em-aberto.md
@@ -1,0 +1,74 @@
+# ADR 0003: Banco de Dados — Self-Hosted em Teste, Produção Decidida por Custo
+
+**Status:** Aceito
+**Data:** 2026-08-17
+**Supera:** ADR 0002 (banco de dados em nuvem gerenciada)
+
+## Contexto
+
+A ADR 0002 decidiu manter o banco em Supabase, partindo do princípio de que a
+infraestrutura Coolify em uso era a mesma que hospedava produção — um PC
+residencial, sem redundância, inadequado pra dado sensível de saúde sob LGPD.
+
+Essa premissa era imprecisa. O ambiente self-hosted atual (`arca`, no mesmo
+servidor Postgres que `chatwoot`, `n8n`, `automacoes`) é especificamente um
+ambiente de **teste**, sem dado real de paciente. A preocupação original da
+ADR 0002 — infraestrutura inadequada pra dado sensível — não se aplica a um
+ambiente sem dado sensível nele. A migração pro Supabase nunca chegou a ser
+executada, só decidida no papel.
+
+Além disso, o ARCA não usa nenhum recurso específico do Supabase (Auth,
+Storage, Realtime, APIs geradas) — autenticação é JWT própria. Ele funciona,
+na prática, só como Postgres gerenciado. Isso abre a pergunta: pra produção,
+faz sentido pagar pela superfície de produto do Supabase, ou um Postgres puro
+resolve, mais barato?
+
+## Decisão
+
+**Ambiente de teste:** self-hosted no Coolify atual é aceitável, sem
+ressalva. Não guarda dado sensível real, então o risco que motivou a ADR 0002
+não existe aqui.
+
+**Banco de produção:** decisão adiada — critério definido é **Postgres puro,
+pela opção mais barata pra um workload sempre ativo** (não intermitente).
+Pesquisa de mercado feita hoje aponta a ordem provável de custo pra esse
+perfil, sem fechar a escolha:
+
+1. **Self-hosted numa VPS de nuvem real** (Hetzner, DigitalOcean) — menor
+   custo bruto. Diferente do PC doméstico: infraestrutura de datacenter, com
+   redundância de energia/rede. Exige Pedro assumir backup, patch e
+   segurança manualmente.
+2. **DigitalOcean Managed PostgreSQL** — totalmente gerenciado (backup
+   automático incluso), ainda na faixa mais barata do mercado. Provável
+   melhor equilíbrio custo/operação.
+3. **Neon** — melhor simplicidade de conexão (string Postgres pura, sem
+   plataforma), mas cobra por hora de computação ativa — vantajoso pra
+   workload intermitente (ambiente de teste/staging), desvantajoso pra banco
+   de produção sempre ligado.
+4. **Supabase** — sem vantagem de custo identificada sobre as opções acima,
+   e carrega superfície de produto (Auth, Storage, Realtime) que o ARCA não
+   usa.
+
+## Consequências
+
+**Positivas:**
+- Ambiente de teste segue exatamente como está, sem trabalho de migração
+  desnecessário
+- Decisão de produção fica ancorada em critério explícito (custo, Postgres
+  puro) em vez de reaberta do zero quando chegar a hora
+- Evita pagar por recursos do Supabase que nunca foram usados
+
+**Negativas / em aberto:**
+- Escolha final de produção não está fechada — precisa ser revisitada antes
+  do primeiro cliente real, com preço então atual (mercado de Postgres
+  gerenciado muda rápido)
+- Se a escolha for self-hosted em VPS, Pedro assume responsabilidade
+  operacional (backup, patch, monitoramento) que um serviço gerenciado
+  absorveria
+
+## Alternativas consideradas
+
+- **Manter a decisão da ADR 0002 (Supabase fechado)**: superada — a premissa
+  que a motivou (infra de teste = infra de produção) não é real, e não há
+  vantagem de custo clara do Supabase sobre alternativas mais simples dado
+  o uso atual do ARCA.

--- a/docs/adr/0004-multi-tenancy-implementado-merge-adiado.md
+++ b/docs/adr/0004-multi-tenancy-implementado-merge-adiado.md
@@ -1,0 +1,105 @@
+# ADR 0004: Multi-Tenancy Implementado e Validado, Merge Adiado
+
+**Status:** Aceito
+**Data:** 2026-08-18
+**Relacionado a:** ADR 0001 (não supera — a decisão de arquitetura continua de pé, isto documenta o momento do deploy)
+
+## Contexto
+
+A ADR 0001 decidiu implementar isolamento multi-tenant agora, com o banco
+ainda vazio, para evitar um retrofit caro e arriscado depois — com dado
+real de paciente em produção. A issue #107 executou essa decisão por
+completo: schema com `Clinica`/`id_Clinica`, `clinicaId` no JWT com
+verificação cruzada contra o banco, Prisma Client Extension
+(`tenant.extension.ts`) com enforcement automático e `$tenantTransaction`,
+Row-Level Security ativo nas 5 tabelas escopadas, e uma função
+`SECURITY DEFINER` (role `arca_auth`, escopada por policy, sem
+`BYPASSRLS` geral) resolvendo o conflito entre RLS e a busca de
+credenciais de login/JWT.
+
+No processo, dois bugs reais foram encontrados e corrigidos com teste de
+integração contra Postgres real: `$tenantTransaction` abrindo transação no
+client errado (não carimbava `id_Clinica` dentro dela), e RLS bloqueando
+o próprio login por falta de `set_config` na busca por e-mail. Ambos
+documentados nos testes `login-lookup-rls.e2e-spec.ts` e
+`jwt-lookup-rls.e2e-spec.ts`.
+
+Apesar da implementação completa e validada, o ARCA continua com uma
+única clínica real em uso. Não há segunda clínica onboardando ainda —
+o pré-requisito que a própria ADR 0001 e a seção 8 do `ARQUITETURA.md`
+já registravam para justificar o trabalho de produto multi-tenant
+(seleção de clínica, personalização, etc.) também vale aqui: sem um
+segundo consumidor real, carregar a complexidade operacional de RLS/CLS/
+extension em produção, para servir exatamente um tenant, é custo sem
+benefício imediato.
+
+## Decisão
+
+Manter a implementação completa na branch
+`107-adicionar-modelo-clinica-e-clinicaid-no-schema-adr-001`, sem merge
+para `development`, até existir uma segunda clínica real confirmada.
+`development` permanece single-tenant enquanto isso.
+
+Correções que também se aplicam ao estado atual (single-tenant) — como o
+fix do CRP truncado no seed, encontrado no caminho — são aplicadas nos
+dois lugares (cherry-pick), não só na branch de tenant.
+
+## Consequências
+
+**Positivas:**
+- O trabalho caro (desenho, implementação, e principalmente debugar RLS/
+  CLS/extension até funcionar ponta a ponta) já está pago como
+  **referência** — a policy de RLS, o padrão da função `SECURITY
+  DEFINER`, os dois bugs reais e como foram resolvidos continuam válidos
+  como ponto de partida, mesmo que a aplicação literal do código exija
+  revisão (ver nota abaixo)
+- `development` continua simples enquanto só uma clínica usa o sistema,
+  sem complexidade operacional carregada à toa
+
+**Negativas:**
+- A branch diverge de `development` com o tempo — outro trabalho feito
+  numa não reflete automaticamente na outra, exigindo rebase/merge
+  cuidadoso quando chegar a hora
+- Fix que vale pros dois estados precisa ser replicado manualmente
+  (cherry-pick), com risco de esquecimento se não for disciplinado
+
+**Pendência conhecida, não resolvida — prioridade antes do merge final:**
+`prisma/seed.ts` roda com um `PrismaClient` cru, sem `set_config`, e não
+consegue popular um banco novo do zero com `FORCE ROW LEVEL SECURITY`
+ativo usando a role normal da aplicação. Isso bloqueia qualquer
+provisionamento futuro de ambiente novo a partir dessa branch — inclusive
+se um dia for preciso recriar o banco atual do zero, não só no cenário de
+segunda clínica. Não deixar isso esquecido junto com o resto.
+
+## Nota para retomada futura
+
+A expectativa é voltar a este trabalho depois que o ARCA passar por uma
+clínica de testes real em produção single-tenant. Nesse meio tempo, é
+provável que bastante coisa mude — tanto em `development` quanto no
+entendimento real do negócio, validado com uso de verdade. Por isso, a
+branch preservada não deve ser tratada como um patch pronto pra aplicar
+direto quando a segunda clínica aparecer: **antes de retomar, é necessário
+revisar a arquitetura inteira novamente, pra confirmar que ela ainda
+reflete a realidade do sistema naquele momento** — schema, regras de
+negócio e decisões podem ter se movido o bastante pra tornar parte da
+implementação obsoleta, mesmo que o raciocínio de fundo (RLS + extension
+como defesa em profundidade) continue válido.
+
+## Referência
+
+Branch: `107-adicionar-modelo-clinica-e-clinicaid-no-schema-adr-001`
+
+Contém: schema completo (Seções 1-2), `clinicaId` no JWT (Seção 3),
+Prisma Client Extension + CLS (Seção 4), RLS nas 5 tabelas (Seção 5),
+transações refatoradas (Seção 6), todos os endpoints migrados (Seção 7),
+os dois fixes de RLS pós-Seção 7, e a suíte e2e (`access-control`,
+`login-lookup-rls`, `jwt-lookup-rls`).
+
+## Alternativas consideradas
+
+- **Merge imediato para `development`**: rejeitado — adicionaria
+  complexidade operacional de produção (RLS, CLS, roles extras) sem
+  benefício correspondente enquanto existe só uma clínica.
+- **Descartar a branch**: rejeitado — jogaria fora trabalho de
+  implementação e debug já validado, reintroduzindo o custo de retrofit
+  que a ADR 0001 existia especificamente para evitar.

--- a/docs/adr/0005-multi-tenancy-merge-para-development.md
+++ b/docs/adr/0005-multi-tenancy-merge-para-development.md
@@ -1,0 +1,98 @@
+# ADR 0005: Multi-Tenancy — Merge para `development` Antes da 2ª Clínica Real
+
+**Status:** Aceito
+**Data:** 2026-08-20
+**Relacionado a:** ADR 0001 (não supera — a decisão de arquitetura continua de pé), ADR 0004 (supera a parte da decisão de adiar o merge)
+
+## Contexto
+
+A ADR 0004 decidiu manter a implementação completa de multi-tenancy (schema,
+extension, RLS) preservada na branch `107-...-adr-001`, sem merge para
+`development`, até existir uma segunda clínica real confirmada — o
+argumento era não carregar complexidade operacional de RLS/CLS em produção
+pra servir exatamente um tenant, sem benefício imediato.
+
+A própria ADR 0004 já previa que, ao retomar esse trabalho, seria
+necessário revisar a arquitetura de novo antes de aplicar, porque parte da
+implementação poderia estar obsoleta. Essa revisão aconteceu antes do
+prazo esperado (não por causa de uma segunda clínica real, mas por decisão
+deliberada de assumir o risco agora) e encontrou dois problemas reais:
+
+1. **Cadastro público na lista de espera** (`WaitlistService.resolveClinicaAtivaContext`)
+   resolvia a clínica do tenant fazendo `findFirstOrThrow({ isActive: true })`
+   — com uma segunda clínica ativa, a resolução de tenant pra um paciente se
+   autocadastrando virava não-determinística, um bug silencioso de
+   isolamento de dados. Corrigido: a clínica agora é resolvida por slug
+   explícito na rota (`/waitlist/:clinicaSlug/...`), não mais inferida.
+
+2. **Clínica desativada não bloqueava login nem revalidação de JWT** —
+   `buscar_usuario_login` e `buscar_usuario_por_id` (funções `SECURITY
+   DEFINER` que existem justamente para descobrir a clínica do usuário
+   antes de haver `app.current_clinica_id` na conexão) checavam apenas
+   `Usuario.isActive`, nunca `Clinica.isActive`. Corrigido via `JOIN` com
+   `CLINICAS` nas duas funções (migration
+   `20260820120000_clinica_isactive_gate_auth_lookups`), incluindo o
+   `GRANT SELECT` em `CLINICAS` pra role `arca_auth` que faltava (sem ele,
+   login e JWT quebravam globalmente com "permission denied for table
+   CLINICAS" — encontrado rodando a suíte e2e completa após a mudança).
+
+Com os dois corrigidos e a suíte e2e completa (incluindo
+`access-control`, `login-lookup-rls`, `jwt-lookup-rls`) passando contra
+Postgres real, o mecanismo de isolamento por tenant (RLS + extension +
+JWT com cross-check) está genuinamente pronto pra mais de uma clínica —
+não só pra uma, como estava quando a ADR 0004 foi escrita.
+
+## Decisão
+
+Mergear a branch `107-adicionar-modelo-clinica-e-clinicaid-no-schema-adr-001`
+para `development` agora, antes de uma segunda clínica real confirmada —
+revertendo a decisão de adiamento da ADR 0004. A clínica única em produção
+continua operando normalmente sob RLS (uma linha em `CLINICAS`, todo
+mundo nela), e a complexidade operacional de RLS/CLS passa a ser
+carregada a partir de agora, não só quando a segunda clínica aparecer.
+
+## Consequências
+
+**Positivas:**
+
+- O gap de isolamento no cadastro público (item 1) deixa de ser uma bomba
+  relógio — não dependia de uma segunda clínica pra virar um problema real
+  de dados, só ainda não tinha sido acionado.
+- Nenhum retrofit de última hora quando a segunda clínica realmente
+  aparecer — o caminho já foi testado ponta a ponta.
+
+**Negativas / trade-offs:**
+
+- Complexidade operacional (RLS, CLS, roles extras) passa a existir em
+  produção sem uma segunda clínica pra justificar o custo imediato — risco
+  que a ADR 0004 apontou e que aqui é conscientemente aceito.
+- `development` deixa de ser single-tenant; qualquer trabalho futuro em
+  cima dela precisa estar ciente do contexto de tenant (CLS/JWT) mesmo
+  operando com uma clínica só.
+
+**Pendências conhecidas, não resolvidas por esta ADR:**
+
+- `prisma/seed.ts` ainda não popula um banco novo do zero com `FORCE ROW
+  LEVEL SECURITY` ativo usando a role normal da aplicação (mesmo apontamento
+  da ADR 0004, mitigado só no ambiente de teste via `global-setup.ts`
+  rodando o seed como role superuser). Isso bloqueia provisionamento de um
+  ambiente novo — inclusive uma eventual recriação do banco de produção.
+  Prioridade antes de depender disso operacionalmente.
+- Não existe endpoint pra criar uma clínica nova nem para provisionar o
+  primeiro admin dela — inserir a segunda clínica continua exigindo acesso
+  direto ao banco (`DIRECT_URL`/role superuser, ou `SET
+  app.current_clinica_id` manual antes do insert, já que `USUARIOS` tem
+  `FORCE ROW LEVEL SECURITY`). Onboarding self-serve de clínica continua
+  fora de escopo (ADR 0001), mas o caminho manual precisa estar documentado
+  antes de ser usado de verdade.
+
+## Alternativas consideradas
+
+- **Manter adiado até a 2ª clínica real (reafirmar ADR 0004)**: rejeitado
+  — decisão de produto de assumir o risco agora, não uma reavaliação
+  técnica; os dois bugs de isolamento encontrados nesta revisão reforçam
+  que valia a pena revisar cedo, mas não eram, por si só, motivo pra
+  adiar mais — foram corrigidos.
+- **Merge parcial (só as correções não-tenant, manter RLS/extension fora)**:
+  rejeitado — deixaria o cadastro público e o RLS de tenant fora de sync,
+  sem reduzir de fato a complexidade adiada, só adiando de novo.

--- a/docs/adr/0006-multi-tenancy-isolamento-fisico-por-banco.md
+++ b/docs/adr/0006-multi-tenancy-isolamento-fisico-por-banco.md
@@ -1,0 +1,194 @@
+# ADR 0006: Multi-Tenancy — Isolamento Físico por Banco de Dados, Substituindo Schema Único com RLS
+
+**Status:** Aceito
+**Data:** 2026-08-20
+**Supera:** ADR 0001 (estratégia de isolamento no schema), ADR 0004 (implementação RLS/schema único) e ADR 0005 (merge desse modelo para `development`)
+
+## Contexto
+
+A ADR 0001 decidiu isolamento multi-tenant via schema único: modelo `Clinica`,
+coluna `id_Clinica` nas tabelas escopadas, Row-Level Security e uma Prisma
+Client Extension injetando o filtro automaticamente. As ADRs 0004 e 0005
+documentam essa implementação completa, validada com testes de integração
+contra Postgres real, e já mergeada em `development`.
+
+Em conversa entre os sócios sobre o modelo de vendas do ARCA como produto,
+ficou claro que esse modelo não é compatível com banco único compartilhado
+entre clínicas — o caminho mais seguro e alinhado ao produto é cada clínica
+ter seu próprio banco de dados isolado fisicamente, não uma linha isolada por
+política de RLS num schema compartilhado.
+
+Isso levanta um problema operacional: hoje, trocar a string de conexão do
+banco exigiria subir um backend novo por clínica, o que não escala. A
+discussão que resultou nesta ADR cobriu como resolver isso de forma dinâmica:
+
+- Um **control plane / registry de tenants** — banco Postgres pequeno e
+  separado de todo dado de paciente — mapeando clínica → connection string,
+  resolvido em tempo de request, para que um único deploy de backend (e
+  frontend) sirva todas as clínicas.
+- A topologia física escolhida para os bancos de clínica: **mesma instância
+  Postgres, um banco (`CREATE DATABASE`) por clínica, com um role dedicado
+  por banco** — não uma instância gerenciada inteira por clínica. Isso evita
+  pagar o custo fixo de N instâncias gerenciadas enquanto a maioria das
+  clínicas ainda é pequena, sem abrir mão de isolamento real: bancos
+  diferentes na mesma instância não são alcançáveis por query cruzada sem
+  `dblink`/`postgres_fdw`, que nunca são instalados/concedidos, e cada role
+  só tem grant no seu próprio banco.
+- Importante deixar registrado: essa topologia isola **vazamento de dado e
+  BOLA cross-tenant** (o motivo original que levou a abandonar RLS), mas
+  **não isola disponibilidade** — se a instância compartilhada cair, todas as
+  clínicas nela caem juntas, assim como acontecia com schema único. O
+  registry de tenants foi desenhado para tornar essa limitação temporária:
+  como ele só guarda uma connection string por clínica, mover uma clínica
+  específica para uma instância dedicada no futuro é uma mudança de dado no
+  control plane, não uma mudança de arquitetura ou de código.
+
+## Decisão
+
+1. Cada clínica tem seu próprio banco de dados físico. Isolamento deixa de
+   ser por `id_Clinica` + RLS e passa a ser por banco separado.
+2. Cada banco de clínica tem um role Postgres dedicado, com grants restritos
+   àquele banco — nenhum role de aplicação alcança mais de um banco de
+   clínica.
+3. Topologia padrão: todos os bancos de clínica vivem na mesma
+   instância/cluster Postgres gerenciado (a escolha de provider da ADR 0003
+   continua valendo). Qualquer clínica pode ser movida para uma instância
+   dedicada depois, trocando só a connection string no control plane.
+4. Um **registry de tenants** — banco Postgres dedicado, sem dado de
+   paciente — guarda por clínica: `slug`, `connectionString` (criptografada
+   em repouso, reaproveitando o padrão do `CryptoService` com uma
+   `ENCRYPTION_KEY` distinta da usada em prontuário), `status`
+   (`provisionando` / `ativa` / `suspensa`) e a versão de schema aplicada.
+5. O `PrismaService` deixa de ser um singleton com uma `DATABASE_URL` fixa.
+   Passa a existir um registry de clients cacheado por tenant no backend:
+   resolve o tenant por request (slug/subdomínio, ou claim `clinicaId` do
+   JWT após login), busca/cacheia um `PrismaClient` apontando para o banco
+   daquela clínica, com LRU e expiração por inatividade para não esgotar
+   `max_connections` da instância compartilhada.
+6. Migrations passam a ser um fan-out: um runner que aplica a mesma migration
+   em cada banco de clínica registrado, de forma idempotente — capaz de
+   reexecutar apenas nos bancos que falharam, sem repetir os que já
+   aplicaram com sucesso.
+7. Provisionamento de clínica nova é um fluxo scriptável: criar banco, criar
+   role, aplicar grants, rodar migrations, popular tabelas de apoio, e só
+   então registrar no control plane com `status = ativa`.
+8. O trabalho de RLS/CLS/Prisma Client Extension (ADR 0001/0004/0005, branch
+   `107-adicionar-modelo-clinica-e-clinicaid-no-schema-adr-001`) deixa de ser
+   a direção ativa da arquitetura. Fica preservado como referência técnica
+   válida (a policy de RLS, o padrão da função `SECURITY DEFINER`, os bugs
+   reais encontrados e como foram corrigidos), caso algum cenário futuro
+   volte a justificar schema compartilhado — mas não é mais o caminho que o
+   produto segue.
+9. Um cache Redis (cache-aside) fica entre os serviços de domínio e o
+   Postgres, para leituras públicas de alto volume repetido — o caso
+   concreto é a consulta de posição na waitlist (`ListaEspera`), rota sem
+   autenticação onde o mesmo paciente reconsulta o próprio status
+   repetidamente. TTL curto, invalidado ativamente quando a fila muda (novo
+   cadastro, atendimento agendado, remoção). Isso reduz volume e duração de
+   query por conexão — complementar ao LRU de `PrismaClient` do item 5, não
+   um substituto: reduz pressão sobre cada pool, mas não reduz quantos pools
+   existem.
+
+### Diagrama: da requisição ao banco da clínica
+
+```mermaid
+flowchart TD
+    Client["Cliente (browser)"] -->|"HTTPS"| Frontend["Next.js — Server Actions"]
+    Frontend -->|"JWT (clinicaId) ou slug público"| API["NestJS API (deploy único)"]
+
+    API --> Resolver["Tenant Resolver (Guard)<br/>lê clinicaId do JWT<br/>ou slug da rota pública"]
+
+    Resolver --> Cache{"PrismaClient já<br/>cacheado pra essa clínica?"}
+
+    Cache -->|"sim (cache hit)"| Services["Serviços de domínio<br/>Waitlist · Session · MedicalRecord · Audit"]
+
+    Cache -->|"não (cache miss)"| CPLookup["busca connectionString<br/>no Control Plane"]
+    CPLookup --> ControlPlaneDB[("Control Plane DB<br/>registry de clínicas<br/>sem dado de paciente")]
+    ControlPlaneDB --> Decrypt["descriptografa a string<br/>(CryptoService)"]
+    Decrypt --> NewClient["instancia PrismaClient novo<br/>cacheia (LRU evita se cheio)"]
+    NewClient --> Services
+
+    Services --> Redis["Redis<br/>cache-aside p/ leituras públicas<br/>(ex: posição na waitlist, TTL curto)"]
+    Redis -->|"cache hit — não toca Postgres"| Response(["Resposta"])
+    Redis -->|"cache miss ou escrita"| Pooler["Pooler (PgBouncer)<br/>opcional — multiplexa conexões"]
+    Pooler -.->|"popula / invalida"| Redis
+
+    subgraph PG["Instância Postgres compartilhada"]
+        Pooler --> DBA[("clinica_a")]
+        Pooler --> DBB[("clinica_b")]
+        Pooler --> DBN[("clinica_n")]
+    end
+```
+
+## Consequências
+
+**Positivas:**
+
+- Elimina estruturalmente o risco de vazamento cross-tenant: não depende de
+  toda query ter o filtro certo, nem de RLS configurado sem furos — o que
+  ADR 0004/0005 mostrou ser real (dois bugs de isolamento encontrados antes
+  de produção, mesmo com o mecanismo bem implementado).
+- Modelo de produto/vendas decidido com o sócio fica viável — cada clínica
+  como unidade de dado isolada, não uma linha entre outras num schema
+  compartilhado.
+- O registry de tenants desacopla a topologia física: começar com bancos
+  compartilhando instância e migrar clínicas específicas para instância
+  dedicada depois é mudança de dado, não redesenho de arquitetura.
+- Provisionamento de clínica nova já nasce como script automatizável — não
+  repete a pendência que ADR 0004/0005 deixaram em aberto (seed manual, sem
+  caminho para criar uma segunda clínica).
+
+**Negativas / trade-offs:**
+
+- Migrations passam a exigir um runner de fan-out com tratamento de falha
+  parcial — peça de infraestrutura nova que não existia com schema único.
+- A topologia padrão (bancos compartilhando instância) não isola
+  disponibilidade: um outage da instância afeta todas as clínicas nela,
+  igual acontecia com schema único. Isolamento de falha por clínica só
+  existe quando/se uma clínica específica for movida para instância
+  dedicada.
+- O registry de tenants vira dependência crítica de todo login/request
+  (mesmo guardando só metadado, não prontuário) — precisa de estratégia
+  própria de cache/disponibilidade para não se tornar um novo ponto único de
+  falha do tamanho do problema que a mudança busca evitar.
+- `max_connections` da instância compartilhada precisa ser dimensionado
+  considerando N bancos com pool próprio cada; sem o LRU de clients
+  cacheados no backend, é fácil esgotar conexões.
+- O trabalho de implementação de RLS/CLS deixa de ser o caminho ativo — não
+  é perda (fica documentado como referência), mas é esforço de engenharia
+  real que não vai virar produção como planejado em ADR 0004/0005.
+
+## Em aberto (fora do escopo desta ADR, identificado na discussão)
+
+- Estratégia de backup/restore por clínica quando vários bancos compartilham
+  a mesma instância gerenciada — depende de o provider (ADR 0003) suportar
+  restore granular por banco, ou exigir `pg_dump` agendado por tenant como
+  estratégia suplementar.
+- Dimensionamento de `max_connections`/pooler (PgBouncer ou nativo do
+  provider) para suportar N bancos com pool cacheado no backend.
+- Desenho concreto do cache Redis do item 9: quais chaves além de posição na
+  waitlist valem cache-aside, TTL por caso de uso, e o mecanismo de
+  invalidação ativa (evento de domínio disparando o invalidate, não só TTL
+  passivo) para não servir posição desatualizada.
+- Desenho concreto do runner de migration fan-out e do fluxo de
+  provisionamento automatizado (criar banco + role + grants + seed +
+  registro no control plane).
+- Critério explícito para quando isolar disponibilidade por clínica
+  (instância dedicada) vira tier comercial, e qual clínica cruza esse
+  limiar.
+
+## Alternativas consideradas
+
+- **Manter schema único com RLS (ADR 0001/0004/0005)**: rejeitado — decisão
+  de negócio (modelo de vendas/produto) tomada com o sócio, incompatível com
+  múltiplas clínicas dividindo o mesmo schema, independente de o mecanismo
+  técnico estar corretamente implementado.
+- **Instância Postgres gerenciada dedicada por clínica desde já**: rejeitado
+  por custo — providers gerenciados cobram por instância, e a maioria das
+  clínicas não justifica esse custo fixo ainda. Fica disponível como opção
+  via mudança no control plane, não como padrão inicial.
+- **Schema-per-tenant (um schema Postgres por clínica, mesmo banco)**: não
+  escolhido — isolamento intermediário entre RLS e banco físico separado,
+  ainda dependente de `search_path`/grants configurados corretamente por
+  schema, sem a garantia estrutural de banco fisicamente separado — e sem
+  vantagem de custo sobre banco separado na mesma instância.


### PR DESCRIPTION
## Resumo
- Simplifica o contrato de resposta do login: o backend agora envia apenas o JWT (`AuthenticatedUserDto` só tem `token`); o front decodifica o token e consome os dados dele.
- Corrige `apps/backend/prisma.config.ts` para carregar `dotenv/config` e usar `directUrl` (necessário para bancos gerenciados com connection pooling).
- Corrige seed do Prisma: campo `CRP` do usuário supervisor sem o prefixo redundante `CRP-`.
- Adiciona documentação de arquitetura pendente: atualização de `docs/ARQUITETURA.md` e novos ADRs (0002 a 0006) cobrindo decisões sobre banco de dados em nuvem gerenciada, banco de produção, e multi-tenancy (incluindo o adiamento do merge e o isolamento físico por banco).

## Test plan
- [ ] Rodar suíte de testes do backend (`auth.service.spec.ts` já foi ajustado para o novo contrato)
- [ ] Validar login end-to-end confirmando que o front decodifica corretamente o JWT retornado
- [ ] Revisar ADRs adicionados quanto à consistência com decisões já tomadas no projeto

🤖 Generated with [Claude Code](https://claude.com/claude-code)