### PR TITLE
fix: corrige comparações inseguras de enum sem migrar schema

### DIFF
--- a/apps/backend/src/auth/dto/local-auth-request.dto.ts
+++ b/apps/backend/src/auth/dto/local-auth-request.dto.ts
@@ -1,8 +1,10 @@
+import { RoleAccess } from 'src/common/enums/status.enum';
+
 export interface LocalAuthRequest {
     user: {
         id_User: string;
         nome: string;
         email: string;
-        roleId: number;
+        roleId: RoleAccess;
     };
 }

--- a/apps/backend/src/auth/dto/validated-user.dto.ts
+++ b/apps/backend/src/auth/dto/validated-user.dto.ts
@@ -1,6 +1,8 @@
+import { RoleAccess } from 'src/common/enums/status.enum';
+
 export interface ValidatedUserDto {
     id_User: string;
     nome: string;
     email: string;
-    roleId: number;
+    roleId: RoleAccess;
 }

--- a/apps/backend/src/medical_record/medical_record.service.ts
+++ b/apps/backend/src/medical_record/medical_record.service.ts
@@ -63,11 +63,13 @@ export class MedicalRecordService {
             },
         });
         if (!atendimento) throw new NotFoundException('Atendimento não encontrado.');
-        if (atendimento?.id_Tipo_Atendimento !== TipoAtendimento.TRIAGEM)
-            throw new BadRequestException('Atendimento não é de triagem.');
-        if (atendimento.id_Status !== StatusAtendimento.ATIVO)
+        const atendimentoTipo: TipoAtendimento = atendimento.id_Tipo_Atendimento;
+        const atendimentoStatus: StatusAtendimento = atendimento.id_Status;
+        const listaEsperaStatus: StatusListaEspera | undefined = atendimento.ListaEspera?.id_Status;
+        if (atendimentoTipo !== TipoAtendimento.TRIAGEM) throw new BadRequestException('Atendimento não é de triagem.');
+        if (atendimentoStatus !== StatusAtendimento.ATIVO)
             throw new BadRequestException('Atendimento não está ativo ou já foi concluido.');
-        if (atendimento.ListaEspera?.id_Status !== StatusListaEspera.EM_TRIAGEM)
+        if (listaEsperaStatus !== StatusListaEspera.EM_TRIAGEM)
             throw new BadRequestException(
                 'Paciente ja possuí triagem concluída ou em andamento. Não é possível criar outra triagem.',
             );
@@ -129,8 +131,10 @@ export class MedicalRecordService {
         });
 
         if (!prontuario) throw new NotFoundException('Registro não encontrado.');
-        if (prontuario.id_Tipo !== TipoProntuario.TRIAGEM) throw new BadRequestException('Registro não é de triagem.');
-        if (prontuario.id_Status !== StatusProntuario.EM_APROVACAO)
+        const prontuarioTipo: TipoProntuario = prontuario.id_Tipo;
+        const prontuarioStatus: StatusProntuario = prontuario.id_Status;
+        if (prontuarioTipo !== TipoProntuario.TRIAGEM) throw new BadRequestException('Registro não é de triagem.');
+        if (prontuarioStatus !== StatusProntuario.EM_APROVACAO)
             throw new BadRequestException('Triagem já foi aprovada, não é possível alterar os dados.');
 
         if (!prontuario.atendimento?.id_Supervisor_Executor)
@@ -165,8 +169,10 @@ export class MedicalRecordService {
         });
 
         if (!prontuario) throw new NotFoundException('Registro não encontrado.');
-        if (prontuario.id_Tipo !== TipoProntuario.TRIAGEM) throw new BadRequestException('Registro não é de triagem.');
-        if (prontuario.id_Status !== StatusProntuario.EM_APROVACAO)
+        const prontuarioTipo: TipoProntuario = prontuario.id_Tipo;
+        const prontuarioStatus: StatusProntuario = prontuario.id_Status;
+        if (prontuarioTipo !== TipoProntuario.TRIAGEM) throw new BadRequestException('Registro não é de triagem.');
+        if (prontuarioStatus !== StatusProntuario.EM_APROVACAO)
             throw new BadRequestException('Triagem já foi aprovada.');
         if (!prontuario.atendimento?.id_Supervisor_Executor)
             throw new InternalServerErrorException('Dados do atendimento inválidos.');
@@ -258,12 +264,14 @@ export class MedicalRecordService {
             },
         });
         if (!atendimento) throw new NotFoundException('Atendimento não encontrado.');
-        if (atendimento?.id_Tipo_Atendimento !== TipoAtendimento.PSICOTERAPIA)
+        const atendimentoTipo: TipoAtendimento = atendimento.id_Tipo_Atendimento;
+        const atendimentoStatus: StatusAtendimento = atendimento.id_Status;
+        if (atendimentoTipo !== TipoAtendimento.PSICOTERAPIA)
             throw new BadRequestException('Atendimento não é de psicoterapia');
-        if (atendimento.id_Status !== StatusAtendimento.ATIVO)
+        if (atendimentoStatus !== StatusAtendimento.ATIVO)
             throw new BadRequestException('Atendimento não está ativo ou já foi concluido.');
 
-        const status = atendimento.ListaEspera?.id_Status;
+        const status: StatusListaEspera | undefined = atendimento.ListaEspera?.id_Status;
         if (status !== StatusListaEspera.TRIAGEM_APROVADA && status !== StatusListaEspera.EM_PSICOTERAPIA)
             throw new BadRequestException(
                 'Paciente não possuí triagem aprovada. Não é possível criar um registro de psicoterapia.',
@@ -329,9 +337,11 @@ export class MedicalRecordService {
         });
 
         if (!prontuario) throw new NotFoundException('Registro não encontrado.');
-        if (prontuario.id_Tipo !== TipoProntuario.PSICOTERAPIA)
+        const prontuarioTipo: TipoProntuario = prontuario.id_Tipo;
+        const prontuarioStatus: StatusProntuario = prontuario.id_Status;
+        if (prontuarioTipo !== TipoProntuario.PSICOTERAPIA)
             throw new BadRequestException('Registro não é de evolução/psicoterapia.');
-        if (prontuario.id_Status !== StatusProntuario.EM_APROVACAO)
+        if (prontuarioStatus !== StatusProntuario.EM_APROVACAO)
             throw new BadRequestException('Registro de evolução já foi aprovado, não é possível alterar os dados.');
 
         if (!prontuario.atendimento?.id_Supervisor_Executor)
@@ -366,9 +376,11 @@ export class MedicalRecordService {
         });
 
         if (!prontuario) throw new NotFoundException('Registro não encontrado.');
-        if (prontuario.id_Tipo !== TipoProntuario.PSICOTERAPIA)
+        const prontuarioTipo: TipoProntuario = prontuario.id_Tipo;
+        const prontuarioStatus: StatusProntuario = prontuario.id_Status;
+        if (prontuarioTipo !== TipoProntuario.PSICOTERAPIA)
             throw new BadRequestException('Registro não é de registro em psicoterapia.');
-        if (prontuario.id_Status !== StatusProntuario.EM_APROVACAO)
+        if (prontuarioStatus !== StatusProntuario.EM_APROVACAO)
             throw new BadRequestException('Registro de psicoterapia já foi aprovado.');
         if (!prontuario.atendimento?.id_Supervisor_Executor)
             throw new InternalServerErrorException('Dados do atendimento inválidos.');
@@ -516,15 +528,18 @@ export class MedicalRecordService {
     async generateAltaPdf(id: UUID, user: TokenDto, res: Response) {
         const paciente = await this.findOne(id, user);
 
-        const atdComAlta = paciente.Atendimento.find((atd) =>
-            atd.Prontuario.some((p) => p.id_Tipo === TipoProntuario.ALTA),
-        );
+        const isAltaRecord = (p: { id_Tipo: number }) => {
+            const tipo: TipoProntuario = p.id_Tipo;
+            return tipo === TipoProntuario.ALTA;
+        };
+
+        const atdComAlta = paciente.Atendimento.find((atd) => atd.Prontuario.some(isAltaRecord));
 
         if (!atdComAlta) {
             throw new NotFoundException('Registro de Alta não encontrado para este paciente.');
         }
 
-        const altaRecord = atdComAlta.Prontuario.find((p) => p.id_Tipo === TipoProntuario.ALTA)!;
+        const altaRecord = atdComAlta.Prontuario.find(isAltaRecord)!;
         const supervisorNome = atdComAlta.supervisorExecutor?.nome ?? 'N/A';
         const supervisorCRP = atdComAlta.supervisorExecutor?.CRP ?? 'N/A';
 
@@ -578,8 +593,9 @@ export class MedicalRecordService {
         if (!encaminhamentoRecord) {
             throw new NotFoundException('Registro de Encaminhamento não encontrado.');
         }
+        const encaminhamentoTipo: TipoProntuario = encaminhamentoRecord.id_Tipo;
 
-        if (encaminhamentoRecord.id_Tipo !== TipoProntuario.ENCAMINHAMENTO) {
+        if (encaminhamentoTipo !== TipoProntuario.ENCAMINHAMENTO) {
             throw new BadRequestException('O registro fornecido não é do tipo Encaminhamento.');
         }
 

--- a/apps/backend/src/session/dto/create-session.dto.ts
+++ b/apps/backend/src/session/dto/create-session.dto.ts
@@ -1,7 +1,8 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsInt, IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+import { IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { UUID } from 'node:crypto';
+import { TipoAtendimento } from 'src/common/enums/status.enum';
 
 export class CreateSessionDto {
     @ApiProperty({ example: '2025-01-15T10:00:00Z', description: 'Data e hora de início do atendimento (ISO 8601)' })
@@ -30,9 +31,9 @@ export class CreateSessionDto {
     id_Supervisor_Executor: UUID;
 
     @ApiProperty({ example: 1, description: 'Tipo do atendimento: 1=Triagem, 2=Psicoterapia' })
-    @IsInt()
+    @IsEnum(TipoAtendimento)
     @IsNotEmpty()
-    id_Tipo_Atendimento: number;
+    id_Tipo_Atendimento: TipoAtendimento;
 
     @ApiPropertyOptional({
         example: 'Paciente solicitou horário vespertino.',

--- a/apps/backend/src/session/session.service.ts
+++ b/apps/backend/src/session/session.service.ts
@@ -109,13 +109,14 @@ export class SessionService {
         if (!paciente) {
             throw new BadRequestException('Paciente não encontrado.');
         }
+        const pacienteStatus: StatusListaEspera = paciente.id_Status;
 
         const statusFinais = [
             StatusListaEspera.RECEBEU_ALTA,
             StatusListaEspera.ENCAMINHADO,
             StatusListaEspera.DESATIVADO,
         ];
-        if (statusFinais.includes(paciente.id_Status)) {
+        if (statusFinais.includes(pacienteStatus)) {
             throw new BadRequestException('Paciente está com um status final e não pode ter novas sessões agendadas.');
         }
 
@@ -128,7 +129,7 @@ export class SessionService {
 
         if (session.id_Tipo_Atendimento === TipoAtendimento.TRIAGEM) {
             // 1 = Triagem
-            if (paciente.id_Status !== StatusListaEspera.EM_ESPERA) {
+            if (pacienteStatus !== StatusListaEspera.EM_ESPERA) {
                 throw new BadRequestException(
                     'Este paciente não está "Em Espera". Não é possível agendar uma nova triagem.',
                 );
@@ -138,13 +139,13 @@ export class SessionService {
 
             const statusPermitidos = [StatusListaEspera.TRIAGEM_APROVADA, StatusListaEspera.EM_PSICOTERAPIA];
 
-            if (!statusPermitidos.includes(paciente.id_Status)) {
-                if (paciente.id_Status === StatusListaEspera.EM_ESPERA) {
+            if (!statusPermitidos.includes(pacienteStatus)) {
+                if (pacienteStatus === StatusListaEspera.EM_ESPERA) {
                     throw new BadRequestException(
                         'Paciente precisa passar pela triagem antes de agendar uma sessão de psicoterapia.',
                     );
                 }
-                if (paciente.id_Status === StatusListaEspera.EM_TRIAGEM) {
+                if (pacienteStatus === StatusListaEspera.EM_TRIAGEM) {
                     throw new BadRequestException(
                         'Paciente está em triagem. A triagem precisa ser aprovada antes de agendar uma sessão de psicoterapia.',
                     );
@@ -160,7 +161,9 @@ export class SessionService {
 
         if (!estagiario) {
             throw new BadRequestException('Estagiário não encontrado.');
-        } else if (estagiario.roleId !== RoleAccess.ESTAGIARIO) {
+        }
+        const estagiarioRole: RoleAccess = estagiario.roleId;
+        if (estagiarioRole !== RoleAccess.ESTAGIARIO) {
             throw new BadRequestException('O usuário designado como estagiário não possui o papel de estagiário.');
         } else if (!estagiario.isActive) {
             throw new BadRequestException('O estagiário designado está desativado.');
@@ -171,7 +174,9 @@ export class SessionService {
         });
         if (!supervisor) {
             throw new BadRequestException('Supervisor não encontrado.');
-        } else if (supervisor.roleId !== RoleAccess.SUPERVISOR) {
+        }
+        const supervisorRole: RoleAccess = supervisor.roleId;
+        if (supervisorRole !== RoleAccess.SUPERVISOR) {
             throw new BadRequestException('O usuário designado como supervisor não possui o papel de supervisor.');
         } else if (!supervisor.isActive) {
             throw new BadRequestException('O supervisor designado está desativado.');
@@ -233,7 +238,7 @@ export class SessionService {
             });
         } else if (
             session.id_Tipo_Atendimento === TipoAtendimento.PSICOTERAPIA &&
-            paciente.id_Status === StatusListaEspera.TRIAGEM_APROVADA
+            pacienteStatus === StatusListaEspera.TRIAGEM_APROVADA
         ) {
             updateListaEsperaPromise = this.prisma.listaEspera.update({
                 where: { id_Lista: session.id_Lista },
@@ -422,19 +427,21 @@ export class SessionService {
         if (!session) {
             throw new NotFoundException('Sessão não encontrada.');
         }
+        const sessionStatus: StatusAtendimento = session.id_Status;
+        const sessionTipo: TipoAtendimento = session.id_Tipo_Atendimento;
 
-        if (session.id_Status !== StatusAtendimento.ATIVO) {
+        if (sessionStatus !== StatusAtendimento.ATIVO) {
             throw new BadRequestException('Só é possível cancelar uma sessão que esteja agendada.');
         }
 
         let updateListaEsperaPromise: Prisma.PrismaPromise<unknown> | null = null;
-        if (session.id_Tipo_Atendimento === TipoAtendimento.TRIAGEM) {
+        if (sessionTipo === TipoAtendimento.TRIAGEM) {
             // Se cancelou uma triagem, paciente volta para "Em espera"
             updateListaEsperaPromise = this.prisma.listaEspera.update({
                 where: { id_Lista: session.id_Lista },
                 data: { id_Status: StatusListaEspera.EM_ESPERA },
             });
-        } else if (session.id_Tipo_Atendimento === TipoAtendimento.PSICOTERAPIA) {
+        } else if (sessionTipo === TipoAtendimento.PSICOTERAPIA) {
             const hasOtherPsicoterapia = await this.prisma.prontuario.findFirst({
                 where: {
                     atendimento: {

--- a/apps/backend/src/users/dto/create-user.dto.ts
+++ b/apps/backend/src/users/dto/create-user.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsEmail, IsInt, IsNotEmpty, IsOptional, IsString, Matches, MaxLength, Min, MinLength } from 'class-validator';
+import { IsEmail, IsEnum, IsNotEmpty, IsOptional, IsString, Matches, MaxLength, MinLength } from 'class-validator';
 import { Transform } from 'class-transformer';
+import { RoleAccess } from 'src/common/enums/status.enum';
 
 export class CreateUserDto {
     @ApiProperty({ example: 'Pedro Silva', description: 'Nome completo do usuário (máx. 50 caracteres)' })
@@ -26,10 +27,9 @@ export class CreateUserDto {
         example: 4,
         description: 'ID do perfil de acesso: 1=Coordenador, 2=Secretário, 3=Supervisor, 4=Estagiário',
     })
-    @IsInt()
-    @Min(1)
+    @IsEnum(RoleAccess)
     @Transform(({ value }: { value: string }) => parseInt(value))
-    roleId: number;
+    roleId: RoleAccess;
 
     @ApiPropertyOptional({
         example: '06/12345',

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -22,7 +22,7 @@ export class UsersService {
         private HashingService: HashingServiceProtocol,
     ) {}
 
-    private canActOnUser(actorAccess: number, targetRoleId: number): boolean {
+    private canActOnUser(actorAccess: RoleAccess, targetRoleId: RoleAccess): boolean {
         return actorAccess < targetRoleId || (actorAccess === RoleAccess.ADMIN && targetRoleId === RoleAccess.ADMIN);
     }
 
@@ -44,9 +44,10 @@ export class UsersService {
                 throw new BadRequestException('E-mail já cadastrado.');
             }
 
+            const existingUserRole: RoleAccess = existingUser.roleId;
             const canReactivate =
-                creator.access < existingUser.roleId ||
-                (creator.access === RoleAccess.ADMIN && existingUser.roleId === RoleAccess.ADMIN);
+                creator.access < existingUserRole ||
+                (creator.access === RoleAccess.ADMIN && existingUserRole === RoleAccess.ADMIN);
 
             if (canReactivate) {
                 throw new ConflictException({
@@ -187,7 +188,8 @@ export class UsersService {
         };
 
         if (updateUserDto.crp !== undefined) {
-            if (user.roleId !== RoleAccess.SUPERVISOR) {
+            const userRole: RoleAccess = user.roleId;
+            if (userRole !== RoleAccess.SUPERVISOR) {
                 throw new BadRequestException(
                     'O campo CRP (Conselho Regional de Psicologia) só pode ser definido para usuários do tipo Supervisor.',
                 );
@@ -251,7 +253,8 @@ export class UsersService {
             throw new BadRequestException('Este usuário já está ativo.');
         }
 
-        if (creator.access >= user.roleId && creator.access !== RoleAccess.ADMIN) {
+        const userRole: RoleAccess = user.roleId;
+        if (creator.access >= userRole && creator.access !== RoleAccess.ADMIN) {
             throw new ForbiddenException('Você não tem permissão para reativar um usuário deste nível de acesso.');
         }
 

--- a/apps/backend/src/waitlist/waitlist.service.ts
+++ b/apps/backend/src/waitlist/waitlist.service.ts
@@ -96,11 +96,12 @@ export class WaitlistService {
         });
 
         const posicao = posicaoNaLista + 1;
+        const status: StatusListaEspera = waitlistEntry.id_Status;
 
         return {
             ...waitlistEntry,
             posicaoNaLista: posicao,
-            situacao: waitlistEntry.id_Status === StatusListaEspera.EM_ESPERA ? 'Ativo' : 'Inativo',
+            situacao: status === StatusListaEspera.EM_ESPERA ? 'Ativo' : 'Inativo',
         };
     }
 
@@ -127,10 +128,12 @@ export class WaitlistService {
             },
         });
 
+        const status: StatusListaEspera = waitlistEntry.id_Status;
+
         return {
             ...waitlistEntry,
             posicaoNaLista: posicaoNaLista + 1,
-            situacao: waitlistEntry.id_Status === StatusListaEspera.EM_ESPERA ? 'Ativo' : 'Inativo',
+            situacao: status === StatusListaEspera.EM_ESPERA ? 'Ativo' : 'Inativo',
         };
     }
 
@@ -212,27 +215,25 @@ export class WaitlistService {
         if (!waitlistEntry) {
             throw new NotFoundException('Paciente não encontrado na lista de espera.');
         }
-        if (waitlistEntry.id_Status === StatusListaEspera.DESATIVADO) {
+        const status: StatusListaEspera = waitlistEntry.id_Status;
+        if (status === StatusListaEspera.DESATIVADO) {
             throw new BadRequestException('Paciente já está desativado na lista de espera.');
         }
-        if (
-            waitlistEntry.id_Status === StatusListaEspera.RECEBEU_ALTA ||
-            waitlistEntry.id_Status === StatusListaEspera.ENCAMINHADO
-        ) {
+        if (status === StatusListaEspera.RECEBEU_ALTA || status === StatusListaEspera.ENCAMINHADO) {
             throw new BadRequestException(
                 'Não é possível desativar um paciente que já recebeu alta ou foi encaminhado.',
             );
         }
-        if (waitlistEntry.id_Status === StatusListaEspera.EM_PSICOTERAPIA) {
+        if (status === StatusListaEspera.EM_PSICOTERAPIA) {
             throw new BadRequestException('Não é possível desativar um paciente que está em psicoterapia.');
         }
-        if (waitlistEntry.id_Status === StatusListaEspera.TRIAGEM_APROVADA) {
+        if (status === StatusListaEspera.TRIAGEM_APROVADA) {
             throw new BadRequestException('Não é possível desativar um paciente com triagem aprovada');
         }
-        if (waitlistEntry.id_Status === StatusListaEspera.EM_TRIAGEM) {
+        if (status === StatusListaEspera.EM_TRIAGEM) {
             throw new BadRequestException('Não é possível desativar um paciente que está em triagem.');
         }
-        if (waitlistEntry.id_Status !== StatusListaEspera.EM_ESPERA) {
+        if (status !== StatusListaEspera.EM_ESPERA) {
             throw new BadRequestException('Apenas pacientes com status "Em espera" podem ser desativados.');
         }
 

--- a/apps/backend/test/access-control.e2e-spec.ts
+++ b/apps/backend/test/access-control.e2e-spec.ts
@@ -19,9 +19,7 @@ describe('Access Control (e2e)', () => {
 
     let adminToken: string;
     let estagiario1Token: string;
-    let estagiario2Token: string;
     let supervisor1Token: string;
-    let supervisor2Token: string;
 
     let estagiario1: { id_User: string };
     let supervisor1: { id_User: string };
@@ -71,16 +69,8 @@ describe('Access Control (e2e)', () => {
             await request(server).post('/auth/login').send({ email: 'estagiario@arca.com', password: 'Estagiario123!' })
         ).body.token;
 
-        estagiario2Token = (
-            await request(server).post('/auth/login').send({ email: 'estagiario2@e2e.com', password: 'Est2E2E123!' })
-        ).body.token;
-
         supervisor1Token = (
             await request(server).post('/auth/login').send({ email: 'supervisor@arca.com', password: 'Supervisor123!' })
-        ).body.token;
-
-        supervisor2Token = (
-            await request(server).post('/auth/login').send({ email: 'supervisor2@e2e.com', password: 'Sup2E2E123!' })
         ).body.token;
 
         paciente1 = await prisma.listaEspera.create({


### PR DESCRIPTION
## Contexto

Relacionado à issue #114 (migração completa dos lookups pra `enum` nativo do Prisma), mas **não** a implementa — essa migração foi avaliada e adiada por ser grande demais pro momento (issue #114 continua aberta pra quando isso for retomado).

Rodando `npx eslint .` em `apps/backend` apareciam 46 erros de `@typescript-eslint/no-unsafe-enum-comparison` em `waitlist.service.ts`, `session.service.ts`, `medical_record.service.ts` e `users.service.ts`. Causa: os campos vindos do Prisma (`roleId`, `id_Status`, `id_Tipo`) são tipados como `number` puro, e eram comparados direto contra os membros do enum TS de `status.enum.ts` — o linter reporta isso com razão, já que nada impedia comparar por engano dois enums de domínios diferentes que compartilham o mesmo valor numérico.

## O que mudou

- DTOs/parâmetros da camada de aplicação retipados de `number` pro enum específico (`create-user.dto.ts`, `create-session.dto.ts`, `validated-user.dto.ts`, `local-auth-request.dto.ts`, `users.service.ts#canActOnUser`), trocando `@IsInt()`/`@Min()` por `@IsEnum()`.
- Nas leituras diretas do Prisma (`waitlist`, `session`, `medical_record`, `users` services), uma variável local com anotação de tipo explícita no ponto de leitura (`const status: StatusListaEspera = entry.id_Status;`) — não `as`, porque TS considera a asserção redundante entre `number` e enum numérico, o que conflita com `no-unnecessary-type-assertion`.
- Limpeza de duas variáveis não utilizadas em `access-control.e2e-spec.ts` (`estagiario2Token`/`supervisor2Token`, já sinalizadas pelo `no-unused-vars`).

Nenhuma mudança de schema, migration ou valor em runtime — só tipagem.

## Test plan

- [x] `npx eslint .` — 0 erros (só warnings pré-existentes de `no-console`/`no-unused-vars`, fora de escopo)
- [x] `npx tsc --noEmit` — sem erros de tipo
- [x] `npx jest` — 136/136 testes passando